### PR TITLE
Make context mutable, update request push method

### DIFF
--- a/Hippo.Web/ClientApp/src/App.tsx
+++ b/Hippo.Web/ClientApp/src/App.tsx
@@ -16,7 +16,7 @@ import { authenticatedFetch } from "./util/api";
 declare var Hippo: AppContextShape;
 
 const App = () => {
-  const [account, setAccount] = useState<Account>();
+  const [context, setContext] = useState<AppContextShape>(Hippo);
 
   const loc = useLocation();
 
@@ -33,10 +33,16 @@ const App = () => {
       if (response.ok) {
         if (response.status === 204) {
           // no content means we have no account record for this person
-          setAccount({ id: 0, status: "create" } as Account);
+          setContext((ctx) => ({
+            ...ctx,
+            account: { id: 0, status: "create" } as Account,
+          }));
         } else {
           const account = (await response.json()) as Account;
-          setAccount(account);
+          setContext((ctx) => ({
+            ...ctx,
+            account,
+          }));
         }
       }
 
@@ -46,10 +52,9 @@ const App = () => {
     fetchAccount();
   }, []);
 
-  if (account) {
-    const context: AppContextShape = { ...Hippo, account };
+  if (context.account) {
     return (
-      <AppContext.Provider value={context}>
+      <AppContext.Provider value={[context, setContext]}>
         <div className={`account-status-${accountClassName}`}>
           <AppNav></AppNav>
           <div className="bottom-svg">

--- a/Hippo.Web/ClientApp/src/Shared/AppContext.ts
+++ b/Hippo.Web/ClientApp/src/Shared/AppContext.ts
@@ -1,10 +1,15 @@
 import React from "react";
 import { Account, AppContextShape, User } from "../types";
 
-const AppContext = React.createContext<AppContextShape>({
-  antiForgeryToken: "",
-  user: { detail: {} as User },
-  account: {} as Account,
-});
+const AppContext = React.createContext<
+  [AppContextShape, React.Dispatch<React.SetStateAction<AppContextShape>>]
+>([
+  {
+    antiForgeryToken: "",
+    user: { detail: {} as User },
+    account: {} as Account,
+  },
+  () => {},
+]);
 
 export default AppContext;

--- a/Hippo.Web/ClientApp/src/components/AccountInfo.tsx
+++ b/Hippo.Web/ClientApp/src/components/AccountInfo.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import AppContext from "../Shared/AppContext";
 
 export const AccountInfo = () => {
-  const { account } = useContext(AppContext);
+  const [{ account }] = useContext(AppContext);
 
   return (
     <div className="row justify-content-center">

--- a/Hippo.Web/ClientApp/src/components/Home.tsx
+++ b/Hippo.Web/ClientApp/src/components/Home.tsx
@@ -4,7 +4,7 @@ import AppContext from "../Shared/AppContext";
 
 // redirect to the proper page depending on current account status
 export const Home = () => {
-  const { account } = useContext(AppContext);
+  const [{ account }] = useContext(AppContext);
 
   return <Redirect to={`/${account.status.toLocaleLowerCase()}`} />;
 };

--- a/Hippo.Web/ClientApp/src/components/RequstForm.tsx
+++ b/Hippo.Web/ClientApp/src/components/RequstForm.tsx
@@ -5,7 +5,7 @@ import { Account, RequestPostModel } from "../types";
 import { authenticatedFetch } from "../util/api";
 
 export const RequestForm = () => {
-  const user = useContext(AppContext).user;
+  const [{ user }] = useContext(AppContext);
 
   const [sponsors, setSponsors] = useState<Account[]>([]);
   const [request, setRequest] = useState<RequestPostModel>({

--- a/Hippo.Web/ClientApp/src/components/RequstForm.tsx
+++ b/Hippo.Web/ClientApp/src/components/RequstForm.tsx
@@ -1,17 +1,20 @@
 import { useContext, useEffect, useState } from "react";
+import { useHistory } from "react-router-dom";
 
 import AppContext from "../Shared/AppContext";
 import { Account, RequestPostModel } from "../types";
 import { authenticatedFetch } from "../util/api";
 
 export const RequestForm = () => {
-  const [{ user }] = useContext(AppContext);
+  const [context, setContext] = useContext(AppContext);
 
   const [sponsors, setSponsors] = useState<Account[]>([]);
   const [request, setRequest] = useState<RequestPostModel>({
     sponsorId: 0,
     sshKey: "",
   });
+
+  const history = useHistory();
 
   // load up possible sponsors
   useEffect(() => {
@@ -21,13 +24,13 @@ export const RequestForm = () => {
       const sponsorResult = await response.json();
 
       if (response.ok) {
-        setSponsors(await sponsorResult);
-        setRequest({ ...request, sponsorId: sponsorResult[0].id });
+        setSponsors(sponsorResult);
+        setRequest((r) => ({ ...r, sponsorId: sponsorResult[0].id }));
       }
     };
 
     fetchSponsors();
-  }, [request]);
+  }, []);
 
   const handleSubmit = async () => {
     const response = await authenticatedFetch("/api/account/create", {
@@ -37,9 +40,8 @@ export const RequestForm = () => {
 
     if (response.ok) {
       const newAccount = await response.json();
-
-      console.log("new acct", newAccount);
-      // do something with it
+      setContext((ctx) => ({ ...ctx, account: newAccount }));
+      history.replace("/"); // could also push straight to pending, but home will redirect there immediately anyway
     }
   };
 
@@ -47,7 +49,8 @@ export const RequestForm = () => {
     <div className="row justify-content-center">
       <div className="col-md-6">
         <h3>
-          Welcome, <span className="status-color">{user.detail.firstName}</span>
+          Welcome,{" "}
+          <span className="status-color">{context.user.detail.firstName}</span>
         </h3>
         <p>
           You don't seem to have an account on Farm yet. If you’d like access,
@@ -79,7 +82,11 @@ export const RequestForm = () => {
             onChange={(e) => setRequest({ ...request, sshKey: e.target.value })}
           ></textarea>
           <p className="form-helper">
-            Paste all of the text from your public SSH file here.
+            Paste all of the text from your public SSH file here. Example:
+            <br></br>
+            <code>
+              -----BEGIN RSA PRIVATE KEY-----ABC123-----END RSA PRIVATE KEY-----
+            </code>
           </p>
         </div>
         <button onClick={handleSubmit} className="btn btn-primary">


### PR DESCRIPTION
Pretty proud of this one, makes it easy for child pages to mutate the account as it changes.  Perhaps we might want to create a separate context just for account info (separate than user) in the future -- for now this seems just fine.  So now the request form just submits to the server, then sets the context and redirects to home