### PR TITLE
Multi-cluster support

### DIFF
--- a/Hippo.Core/Models/AccountDetail.cs
+++ b/Hippo.Core/Models/AccountDetail.cs
@@ -7,6 +7,7 @@ namespace Hippo.Core.Models
         public int Id { get; set; }
         public string Name { get; set; }
         public string Status { get; set; }
+        public bool CanSponsor { get; set; }
         public string Owner { get; set; }
         public string Cluster { get; set; }
         public string Sponsor { get; set; }

--- a/Hippo.Core/Models/AccountDetail.cs
+++ b/Hippo.Core/Models/AccountDetail.cs
@@ -11,5 +11,6 @@ namespace Hippo.Core.Models
         public string Owner { get; set; }
         public string Cluster { get; set; }
         public string Sponsor { get; set; }
+        public bool IsAdmin { get; set; }
     }
 }

--- a/Hippo.Core/Models/AccountDetail.cs
+++ b/Hippo.Core/Models/AccountDetail.cs
@@ -1,0 +1,14 @@
+using Hippo.Core.Domain;
+
+namespace Hippo.Core.Models
+{
+    public class AccountDetail
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public string Status { get; set; }
+        public string Owner { get; set; }
+        public string Cluster { get; set; }
+        public string Sponsor { get; set; }
+    }
+}

--- a/Hippo.Core/Services/UserService.cs
+++ b/Hippo.Core/Services/UserService.cs
@@ -71,7 +71,8 @@ namespace Hippo.Core.Services
                 Status = a.Status,
                 Owner = a.Owner.Name,
                 Cluster = a.Cluster.Name,
-                Sponsor = a.Sponsor.Name
+                Sponsor = a.Sponsor.Name,
+                IsAdmin = a.IsAdmin,
             }).ToListAsync();
             return JsonSerializer.Serialize(accounts, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
         }

--- a/Hippo.Core/Services/UserService.cs
+++ b/Hippo.Core/Services/UserService.cs
@@ -67,6 +67,7 @@ namespace Hippo.Core.Services
             var accounts = await _dbContext.Accounts.Where(a => a.Owner.Iam == iamId).Select(a => new AccountDetail {
                 Id = a.Id,
                 Name = a.Name,
+                CanSponsor = a.CanSponsor,
                 Status = a.Status,
                 Owner = a.Owner.Name,
                 Cluster = a.Cluster.Name,

--- a/Hippo.Web/ClientApp/src/App.test.tsx
+++ b/Hippo.Web/ClientApp/src/App.test.tsx
@@ -1,25 +1,11 @@
-import React from "react";
 import ReactDOM from "react-dom";
 import { MemoryRouter } from "react-router-dom";
 import App from "./App";
-import { fakeAccounts, fakeAppContext } from "./test/mockData";
-import { responseMap } from "./test/testHelpers";
+import { fakeAppContext } from "./test/mockData";
 import { act } from "react-dom/test-utils";
 
 beforeEach(() => {
-  const accountResponse = Promise.resolve({
-    status: 200,
-    ok: true,
-    json: () => Promise.resolve(fakeAccounts[0]),
-  });
-
   (global as any).Hippo = fakeAppContext;
-
-  global.fetch = jest.fn().mockImplementation((x) =>
-    responseMap(x, {
-      "/api/account/get": accountResponse,
-    })
-  );
 });
 
 afterEach(() => {

--- a/Hippo.Web/ClientApp/src/App.test.tsx
+++ b/Hippo.Web/ClientApp/src/App.test.tsx
@@ -26,5 +26,4 @@ it("renders without crashing", async () => {
       div
     );
   });
-  await new Promise((resolve) => setTimeout(resolve, 1000));
 });

--- a/Hippo.Web/ClientApp/src/App.tsx
+++ b/Hippo.Web/ClientApp/src/App.tsx
@@ -50,7 +50,7 @@ const App = () => {
               <Route path="/multiple" component={Multiple} />
               <ConditionalRoute
                 roles={["Sponsor"]}
-                path="/approve"
+                path="/:cluster/approve"
                 component={ApproveAccounts}
               />
               <ConditionalRoute

--- a/Hippo.Web/ClientApp/src/App.tsx
+++ b/Hippo.Web/ClientApp/src/App.tsx
@@ -1,9 +1,9 @@
-import React, { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { Route, Switch, useLocation } from "react-router-dom";
 
 import { AppNav } from "./AppNav";
 import AppContext from "./Shared/AppContext";
-import { Account, AppContextShape } from "./types";
+import { AppContextShape } from "./types";
 import BottomSvg from "./Shared/bottomSvg";
 
 import { Home } from "./components/Home";
@@ -12,13 +12,13 @@ import { RequestForm } from "./components/Account/RequestForm";
 import { PendingApproval } from "./components/Account/PendingApproval";
 import { ApproveAccounts } from "./components/Account/ApproveAccounts";
 import { SponsoredAccounts } from "./components/Account/SponsoredAccounts";
-import { authenticatedFetch } from "./util/api";
 import { AdminUsers } from "./components/Admin/AdminUsers";
 import { Sponsors } from "./components/Admin/Sponsors";
 import { AdminApproveAccounts } from "./components/Admin/AdminApproveAccounts";
 import { ConditionalRoute } from "./ConditionalRoute";
 import { ModalProvider } from "react-modal-hook";
 import { Toaster } from "react-hot-toast";
+import { Multiple } from "./components/Account/Multiple";
 
 declare var Hippo: AppContextShape;
 
@@ -32,34 +32,7 @@ const App = () => {
     [loc.pathname]
   );
 
-  useEffect(() => {
-    // query for user account status
-    const fetchAccount = async () => {
-      const response = await authenticatedFetch("/api/account/get");
-
-      if (response.ok) {
-        if (response.status === 204) {
-          // no content means we have no account record for this person
-          setContext((ctx) => ({
-            ...ctx,
-            account: { id: 0, status: "create" } as Account,
-          }));
-        } else {
-          const account = (await response.json()) as Account;
-          setContext((ctx) => ({
-            ...ctx,
-            account,
-          }));
-        }
-      }
-
-      // TODO: handle error case
-    };
-
-    fetchAccount();
-  }, []);
-
-  if (context.account) {
+  if (context.accounts.length > 0) {
     return (
       <AppContext.Provider value={[context, setContext]}>
         <ModalProvider>
@@ -71,9 +44,10 @@ const App = () => {
             </div>
             <Switch>
               <Route exact path="/" component={Home} />
-              <Route path="/active" component={AccountInfo} />
-              <Route path="/pendingapproval" component={PendingApproval} />
+              <Route path="/:cluster/active" component={AccountInfo} />
+              <Route path="/:cluster/pendingapproval" component={PendingApproval} />
               <Route path="/create" component={RequestForm} />
+              <Route path="/multiple" component={Multiple} />
               <ConditionalRoute
                 roles={["Sponsor"]}
                 path="/approve"

--- a/Hippo.Web/ClientApp/src/App.tsx
+++ b/Hippo.Web/ClientApp/src/App.tsx
@@ -32,60 +32,54 @@ const App = () => {
     [loc.pathname]
   );
 
-  if (context.accounts.length > 0) {
-    return (
-      <AppContext.Provider value={[context, setContext]}>
-        <ModalProvider>
-          <Toaster />
-          <div className={`account-status-${accountClassName}`}>
-            <AppNav></AppNav>
-            <div className="top-svg">
-              <BottomSvg />
-            </div>
-            <Switch>
-              <Route exact path="/" component={Home} />
-              <Route path="/:cluster/active" component={AccountInfo} />
-              <Route path="/:cluster/pendingapproval" component={PendingApproval} />
-              <Route path="/create" component={RequestForm} />
-              <Route path="/multiple" component={Multiple} />
-              <ConditionalRoute
-                roles={["Sponsor"]}
-                path="/:cluster/approve"
-                component={ApproveAccounts}
-              />
-              <ConditionalRoute
-                roles={["Sponsor"]}
-                path="/:cluster/sponsored"
-                component={SponsoredAccounts}
-              />
-              <ConditionalRoute
-                roles={["Admin"]}
-                path="/:cluster/admin/users"
-                component={AdminUsers}
-              />
-              <ConditionalRoute
-                roles={["Admin"]}
-                path="/:cluster/admin/sponsors"
-                component={Sponsors}
-              />
-              <ConditionalRoute
-                roles={["Admin"]}
-                path="/:cluster/admin/accountApprovals"
-                component={AdminApproveAccounts}
-              />
-            </Switch>
+  return (
+    <AppContext.Provider value={[context, setContext]}>
+      <ModalProvider>
+        <Toaster />
+        <div className={`account-status-${accountClassName}`}>
+          <AppNav></AppNav>
+          <div className="top-svg">
+            <BottomSvg />
           </div>
-        </ModalProvider>
-      </AppContext.Provider>
-    );
-  } else {
-    //center div
-    return (
-      <div className="row justify-content-center">
-        <div className="col-md-8">Loading...</div>
-      </div>
-    );
-  }
+          <Switch>
+            <Route exact path="/" component={Home} />
+            <Route path="/:cluster/active" component={AccountInfo} />
+            <Route
+              path="/:cluster/pendingapproval"
+              component={PendingApproval}
+            />
+            <Route path="/:cluster/create" component={RequestForm} />
+            <Route path="/multiple" component={Multiple} />
+            <ConditionalRoute
+              roles={["Sponsor"]}
+              path="/:cluster/approve"
+              component={ApproveAccounts}
+            />
+            <ConditionalRoute
+              roles={["Sponsor"]}
+              path="/:cluster/sponsored"
+              component={SponsoredAccounts}
+            />
+            <ConditionalRoute
+              roles={["Admin"]}
+              path="/:cluster/admin/users"
+              component={AdminUsers}
+            />
+            <ConditionalRoute
+              roles={["Admin"]}
+              path="/:cluster/admin/sponsors"
+              component={Sponsors}
+            />
+            <ConditionalRoute
+              roles={["Admin"]}
+              path="/:cluster/admin/accountApprovals"
+              component={AdminApproveAccounts}
+            />
+          </Switch>
+        </div>
+      </ModalProvider>
+    </AppContext.Provider>
+  );
 };
 
 export default App;

--- a/Hippo.Web/ClientApp/src/App.tsx
+++ b/Hippo.Web/ClientApp/src/App.tsx
@@ -55,22 +55,22 @@ const App = () => {
               />
               <ConditionalRoute
                 roles={["Sponsor"]}
-                path="/sponsored"
+                path="/:cluster/sponsored"
                 component={SponsoredAccounts}
               />
               <ConditionalRoute
                 roles={["Admin"]}
-                path="/admin/users"
+                path="/:cluster/admin/users"
                 component={AdminUsers}
               />
               <ConditionalRoute
                 roles={["Admin"]}
-                path="/admin/sponsors"
+                path="/:cluster/admin/sponsors"
                 component={Sponsors}
               />
               <ConditionalRoute
                 roles={["Admin"]}
-                path="/admin/accountApprovals"
+                path="/:cluster/admin/accountApprovals"
                 component={AdminApproveAccounts}
               />
             </Switch>

--- a/Hippo.Web/ClientApp/src/AppNav.tsx
+++ b/Hippo.Web/ClientApp/src/AppNav.tsx
@@ -1,8 +1,15 @@
-import { NavLink } from "react-router-dom";
+import { NavLink, useRouteMatch } from "react-router-dom";
 import HippoLogo from "./Shared/hippoLogo";
 import { ShowFor } from "./Shared/ShowFor";
 
+interface IRouteParams {
+  cluster: string;
+}
+
 export const AppNav = () => {
+  const match = useRouteMatch<IRouteParams>("/:cluster/:path");
+  const cluster = match?.params.cluster;
+
   return (
     <div>
       <div className="row appheader justify-content-center">
@@ -22,7 +29,7 @@ export const AppNav = () => {
             <ShowFor roles={["Sponsor"]}>
               <NavLink
                 id="sponsorApprove"
-                to="/approve"
+                to={`/${cluster}/approve`}
                 className="nav-item nav-link"
                 activeStyle={{
                   fontWeight: "bold",
@@ -32,7 +39,7 @@ export const AppNav = () => {
               </NavLink>
               <NavLink
                 id="sponsored"
-                to="/sponsored"
+                to={`/${cluster}/sponsored`}
                 className="nav-item nav-link"
                 activeStyle={{
                   fontWeight: "bold",
@@ -45,7 +52,7 @@ export const AppNav = () => {
               <NavLink
                 id="adminApprovals"
                 className="nav-item nav-link"
-                to="/admin/accountApprovals"
+                to={`/${cluster}/admin/accountApprovals`}
                 activeStyle={{
                   fontWeight: "bold",
                 }}
@@ -56,7 +63,7 @@ export const AppNav = () => {
               <NavLink
                 id="AdminIndex"
                 className="nav-item nav-link"
-                to="/admin/users"
+                to={`/${cluster}/admin/users`}
                 activeStyle={{
                   fontWeight: "bold",
                 }}
@@ -67,7 +74,7 @@ export const AppNav = () => {
               <NavLink
                 id="adminSponsors"
                 className="nav-item nav-link"
-                to="/admin/sponsors"
+                to={`/${cluster}/admin/sponsors`}
                 activeStyle={{
                   fontWeight: "bold",
                 }}

--- a/Hippo.Web/ClientApp/src/AppNav.tsx
+++ b/Hippo.Web/ClientApp/src/AppNav.tsx
@@ -1,10 +1,7 @@
 import { NavLink, useRouteMatch } from "react-router-dom";
 import HippoLogo from "./Shared/hippoLogo";
 import { ShowFor } from "./Shared/ShowFor";
-
-interface IRouteParams {
-  cluster: string;
-}
+import { IRouteParams } from "./types";
 
 export const AppNav = () => {
   const match = useRouteMatch<IRouteParams>("/:cluster/:path");
@@ -23,68 +20,71 @@ export const AppNav = () => {
           <p className="lede">High Performance Personnel Onboarding</p>
         </div>
       </div>
-      <div className="row justify-content-center">
-        <div className="col-md-8">
-          <nav className="simple-nav">
-            <ShowFor roles={["Sponsor"]}>
-              <NavLink
-                id="sponsorApprove"
-                to={`/${cluster}/approve`}
-                className="nav-item nav-link"
-                activeStyle={{
-                  fontWeight: "bold",
-                }}
-              >
-                Pending Approvals
-              </NavLink>
-              <NavLink
-                id="sponsored"
-                to={`/${cluster}/sponsored`}
-                className="nav-item nav-link"
-                activeStyle={{
-                  fontWeight: "bold",
-                }}
-              >
-                Sponsored Accounts
-              </NavLink>
-            </ShowFor>
-            <ShowFor roles={["Admin"]}>
-              <NavLink
-                id="adminApprovals"
-                className="nav-item nav-link"
-                to={`/${cluster}/admin/accountApprovals`}
-                activeStyle={{
-                  fontWeight: "bold",
-                }}
-              >
-                Override Approvals
-              </NavLink>
+      {/* Only show links if a cluster has been identified */}
+      {cluster && (
+        <div className="row justify-content-center">
+          <div className="col-md-8">
+            <nav className="simple-nav">
+              <ShowFor cluster={cluster} roles={["Sponsor"]}>
+                <NavLink
+                  id="sponsorApprove"
+                  to={`/${cluster}/approve`}
+                  className="nav-item nav-link"
+                  activeStyle={{
+                    fontWeight: "bold",
+                  }}
+                >
+                  Pending Approvals
+                </NavLink>
+                <NavLink
+                  id="sponsored"
+                  to={`/${cluster}/sponsored`}
+                  className="nav-item nav-link"
+                  activeStyle={{
+                    fontWeight: "bold",
+                  }}
+                >
+                  Sponsored Accounts
+                </NavLink>
+              </ShowFor>
+              <ShowFor cluster={cluster} roles={["Admin"]}>
+                <NavLink
+                  id="adminApprovals"
+                  className="nav-item nav-link"
+                  to={`/${cluster}/admin/accountApprovals`}
+                  activeStyle={{
+                    fontWeight: "bold",
+                  }}
+                >
+                  Override Approvals
+                </NavLink>
 
-              <NavLink
-                id="AdminIndex"
-                className="nav-item nav-link"
-                to={`/${cluster}/admin/users`}
-                activeStyle={{
-                  fontWeight: "bold",
-                }}
-              >
-                Manage Admins
-              </NavLink>
+                <NavLink
+                  id="AdminIndex"
+                  className="nav-item nav-link"
+                  to={`/${cluster}/admin/users`}
+                  activeStyle={{
+                    fontWeight: "bold",
+                  }}
+                >
+                  Manage Admins
+                </NavLink>
 
-              <NavLink
-                id="adminSponsors"
-                className="nav-item nav-link"
-                to={`/${cluster}/admin/sponsors`}
-                activeStyle={{
-                  fontWeight: "bold",
-                }}
-              >
-                Manage Sponsors
-              </NavLink>
-            </ShowFor>
-          </nav>
+                <NavLink
+                  id="adminSponsors"
+                  className="nav-item nav-link"
+                  to={`/${cluster}/admin/sponsors`}
+                  activeStyle={{
+                    fontWeight: "bold",
+                  }}
+                >
+                  Manage Sponsors
+                </NavLink>
+              </ShowFor>
+            </nav>
+          </div>
         </div>
-      </div>
+      )}
     </div>
   );
 };

--- a/Hippo.Web/ClientApp/src/ConditionalRoute.tsx
+++ b/Hippo.Web/ClientApp/src/ConditionalRoute.tsx
@@ -16,10 +16,7 @@ export const ConditionalRoute = (props: ConditionalRouteProps) => {
 
   // if the user has System role they can see everything (But we don't have a roles table yet)
   const systemUsers = ["jsylvest", "postit", "cydoval", "sweber"];
-  if (
-    context.user.detail.isAdmin ||
-    systemUsers.includes(context.user.detail.kerberos)
-  ) {
+  if (systemUsers.includes(context.user.detail.kerberos)) {
     return <Route {...props} />;
   }
 
@@ -27,6 +24,12 @@ export const ConditionalRoute = (props: ConditionalRouteProps) => {
   const clusterAccount = context.accounts.find((a) => a.cluster === cluster);
 
   if (clusterAccount) {
+    if (props.roles.includes("Admin")) {
+      if (clusterAccount.isAdmin) {
+        return <Route {...props} />;
+      }
+    }
+
     if (props.roles.includes("Sponsor")) {
       if (clusterAccount.canSponsor) {
         return <Route {...props} />;

--- a/Hippo.Web/ClientApp/src/ConditionalRoute.tsx
+++ b/Hippo.Web/ClientApp/src/ConditionalRoute.tsx
@@ -1,9 +1,9 @@
 import React, { useContext } from "react";
 
-import { Route, RouteProps } from "react-router-dom";
+import { Route, RouteProps, useRouteMatch } from "react-router-dom";
 
 import AppContext from "./Shared/AppContext";
-import { RoleName } from "./types";
+import { IRouteParams, RoleName } from "./types";
 
 interface ConditionalRouteProps extends RouteProps {
   roles: RoleName[];
@@ -11,6 +11,8 @@ interface ConditionalRouteProps extends RouteProps {
 
 export const ConditionalRoute = (props: ConditionalRouteProps) => {
   const [context] = useContext(AppContext);
+  const match = useRouteMatch<IRouteParams>("/:cluster/:path");
+  const cluster = match?.params.cluster;
 
   // if the user has System role they can see everything (But we don't have a roles table yet)
   const systemUsers = ["jsylvest", "postit", "cydoval", "sweber"];
@@ -21,9 +23,14 @@ export const ConditionalRoute = (props: ConditionalRouteProps) => {
     return <Route {...props} />;
   }
 
-  if (props.roles.includes("Sponsor")) {
-    if (context.accounts[0].canSponsor) {
-      return <Route {...props} />;
+  // Not an admin, determine if they have sufficient permissions within this cluster
+  const clusterAccount = context.accounts.find((a) => a.cluster === cluster);
+
+  if (clusterAccount) {
+    if (props.roles.includes("Sponsor")) {
+      if (clusterAccount.canSponsor) {
+        return <Route {...props} />;
+      }
     }
   }
 

--- a/Hippo.Web/ClientApp/src/ConditionalRoute.tsx
+++ b/Hippo.Web/ClientApp/src/ConditionalRoute.tsx
@@ -22,7 +22,7 @@ export const ConditionalRoute = (props: ConditionalRouteProps) => {
   }
 
   if (props.roles.includes("Sponsor")) {
-    if (context.account.canSponsor) {
+    if (context.accounts[0].canSponsor) {
       return <Route {...props} />;
     }
   }

--- a/Hippo.Web/ClientApp/src/Shared/AppContext.ts
+++ b/Hippo.Web/ClientApp/src/Shared/AppContext.ts
@@ -7,7 +7,7 @@ const AppContext = React.createContext<
   {
     antiForgeryToken: "",
     user: { detail: {} as User },
-    account: {} as Account,
+    accounts: [] as Account[]
   },
   () => {},
 ]);

--- a/Hippo.Web/ClientApp/src/Shared/ShowFor.tsx
+++ b/Hippo.Web/ClientApp/src/Shared/ShowFor.tsx
@@ -7,9 +7,11 @@ import { isBoolean, isFunction } from "../util/TypeChecks";
 interface Props {
   children: any;
   roles: RoleName[];
+  cluster: string;
   condition?: boolean | (() => boolean);
 }
 
+// Determines if the user has access to the route based on roles and cluster
 export const ShowFor = (props: Props) => {
   const { children, roles } = props;
   const [context] = useContext(AppContext);

--- a/Hippo.Web/ClientApp/src/Shared/ShowFor.tsx
+++ b/Hippo.Web/ClientApp/src/Shared/ShowFor.tsx
@@ -27,8 +27,9 @@ export const ShowFor = (props: Props) => {
     return <>{children}</>;
   }
 
+  // TODO: handle multiple accounts
   if (conditionSatisfied && roles.includes("Sponsor")) {
-    if (context.account.canSponsor) {
+    if (context.accounts[0].canSponsor) {
       return <>{children}</>;
     }
   }

--- a/Hippo.Web/ClientApp/src/Shared/ShowFor.tsx
+++ b/Hippo.Web/ClientApp/src/Shared/ShowFor.tsx
@@ -1,8 +1,9 @@
 import React, { useContext } from "react";
 
 import AppContext from "./AppContext";
-import { RoleName } from "../types";
+import { IRouteParams, RoleName } from "../types";
 import { isBoolean, isFunction } from "../util/TypeChecks";
+import { useRouteMatch } from "react-router-dom";
 
 interface Props {
   children: any;
@@ -15,6 +16,9 @@ interface Props {
 export const ShowFor = (props: Props) => {
   const { children, roles } = props;
   const [context] = useContext(AppContext);
+  const match = useRouteMatch<IRouteParams>("/:cluster/:path");
+  const cluster = match?.params.cluster;
+
   const systemUsers = ["jsylvest", "postit", "cydoval", "sweber"];
   const conditionSatisfied = isBoolean(props.condition)
     ? props.condition
@@ -29,16 +33,20 @@ export const ShowFor = (props: Props) => {
     return <>{children}</>;
   }
 
-  // TODO: handle multiple accounts
-  if (conditionSatisfied && roles.includes("Sponsor")) {
-    if (context.accounts[0].canSponsor) {
-      return <>{children}</>;
+  // not admin, need to check roles within the cluster
+  const clusterAccount = context.accounts.find((a) => a.cluster === cluster);
+  
+  if (clusterAccount) {
+    if (conditionSatisfied && roles.includes("Sponsor")) {
+      if (clusterAccount.canSponsor) {
+        return <>{children}</>;
+      }
     }
-  }
 
-  if (conditionSatisfied && roles.includes("Admin")) {
-    if (context.user.detail.isAdmin) {
-      return <>{children}</>;
+    if (conditionSatisfied && roles.includes("Admin")) {
+      if (clusterAccount.isAdmin) {
+        return <>{children}</>;
+      }
     }
   }
 

--- a/Hippo.Web/ClientApp/src/components/Account/AccountInfo.tsx
+++ b/Hippo.Web/ClientApp/src/components/Account/AccountInfo.tsx
@@ -9,7 +9,7 @@ export const AccountInfo = () => {
       <div className="col-md-8">
         <p>
           Welcome {context.user.detail.firstName} you already have an account,
-          enjoy farm
+          enjoy!
         </p>
       </div>
     </div>

--- a/Hippo.Web/ClientApp/src/components/Account/ApproveAccounts.test.tsx
+++ b/Hippo.Web/ClientApp/src/components/Account/ApproveAccounts.test.tsx
@@ -11,6 +11,7 @@ import { act, Simulate } from "react-dom/test-utils";
 import AppContext from "../../Shared/AppContext";
 import { ModalProvider } from "react-modal-hook";
 
+const testCluster = fakeAccounts[0].cluster;
 let container: Element;
 
 beforeEach(() => {
@@ -30,8 +31,8 @@ beforeEach(() => {
 
   global.fetch = jest.fn().mockImplementation((x) =>
     responseMap(x, {
-      "/api/account/pending": accountResponse,
-      "api/account/approve/1": approveResponse,
+      [`/api/caesfarm/account/pending`]: accountResponse,
+      [`api/caesfarm/account/approve/1`]: approveResponse,
     })
   );
 });
@@ -51,7 +52,7 @@ it("shows pending approvals count", async () => {
     render(
       <AppContext.Provider value={(global as any).Hippo}>
         <ModalProvider>
-          <MemoryRouter>
+          <MemoryRouter initialEntries={['/caesfarm/approve']}>
             <ApproveAccounts />
           </MemoryRouter>
         </ModalProvider>
@@ -204,7 +205,7 @@ it("calls approve and filters list when approve is clicked", async () => {
   );
 
   expect(global.fetch).toHaveBeenCalledTimes(2);
-  expect(global.fetch).toHaveBeenCalledWith("/api/account/pending", {
+  expect(global.fetch).toHaveBeenCalledWith(`/api/${testCluster}/account/pending`, {
     credentials: "include",
     headers: {
       Accept: "application/json",
@@ -212,7 +213,7 @@ it("calls approve and filters list when approve is clicked", async () => {
       RequestVerificationToken: "fakeAntiForgeryToken",
     },
   });
-  expect(global.fetch).toHaveBeenLastCalledWith("/api/account/approve/1", {
+  expect(global.fetch).toHaveBeenLastCalledWith(`/api/${testCluster}/account/approve/1`, {
     credentials: "include",
     headers: {
       Accept: "application/json",

--- a/Hippo.Web/ClientApp/src/components/Account/ApproveAccounts.test.tsx
+++ b/Hippo.Web/ClientApp/src/components/Account/ApproveAccounts.test.tsx
@@ -4,14 +4,16 @@ import { MemoryRouter } from "react-router-dom";
 
 import { fakeAccounts, fakeAppContext } from "../../test/mockData";
 import { responseMap } from "../../test/testHelpers";
-import { ApproveAccounts } from "./ApproveAccounts";
 
 import { act, Simulate } from "react-dom/test-utils";
 
 import AppContext from "../../Shared/AppContext";
 import { ModalProvider } from "react-modal-hook";
+import App from "../../App";
 
 const testCluster = fakeAccounts[0].cluster;
+const approveUrl = `/${testCluster}/approve`;
+
 let container: Element;
 
 beforeEach(() => {
@@ -31,8 +33,8 @@ beforeEach(() => {
 
   global.fetch = jest.fn().mockImplementation((x) =>
     responseMap(x, {
-      [`/api/caesfarm/account/pending`]: accountResponse,
-      [`api/caesfarm/account/approve/1`]: approveResponse,
+      [`/api/${testCluster}/account/pending`]: accountResponse,
+      [`api/${testCluster}/account/approve/1`]: approveResponse,
     })
   );
 });
@@ -50,13 +52,9 @@ afterEach(() => {
 it("shows pending approvals count", async () => {
   await act(async () => {
     render(
-      <AppContext.Provider value={(global as any).Hippo}>
-        <ModalProvider>
-          <MemoryRouter initialEntries={['/caesfarm/approve']}>
-            <ApproveAccounts />
-          </MemoryRouter>
-        </ModalProvider>
-      </AppContext.Provider>,
+      <MemoryRouter initialEntries={[approveUrl]}>
+        <App />
+      </MemoryRouter>,
       container
     );
   });
@@ -68,13 +66,9 @@ it("shows pending approvals count", async () => {
 it("shows approval button for each pending account", async () => {
   await act(async () => {
     render(
-      <AppContext.Provider value={(global as any).Hippo}>
-        <ModalProvider>
-          <MemoryRouter>
-            <ApproveAccounts />
-          </MemoryRouter>
-        </ModalProvider>
-      </AppContext.Provider>,
+      <MemoryRouter initialEntries={[approveUrl]}>
+        <App />
+      </MemoryRouter>,
       container
     );
   });
@@ -84,13 +78,9 @@ it("shows approval button for each pending account", async () => {
 it("shows reject button for each pending account", async () => {
   await act(async () => {
     render(
-      <AppContext.Provider value={(global as any).Hippo}>
-        <ModalProvider>
-          <MemoryRouter>
-            <ApproveAccounts />
-          </MemoryRouter>
-        </ModalProvider>
-      </AppContext.Provider>,
+      <MemoryRouter initialEntries={[approveUrl]}>
+        <App />
+      </MemoryRouter>,
       container
     );
   });
@@ -100,13 +90,9 @@ it("shows reject button for each pending account", async () => {
 it("approve button has expected text", async () => {
   await act(async () => {
     render(
-      <AppContext.Provider value={(global as any).Hippo}>
-        <ModalProvider>
-          <MemoryRouter>
-            <ApproveAccounts />
-          </MemoryRouter>
-        </ModalProvider>
-      </AppContext.Provider>,
+      <MemoryRouter initialEntries={[approveUrl]}>
+        <App />
+      </MemoryRouter>,
       container
     );
   });
@@ -117,13 +103,9 @@ it("approve button has expected text", async () => {
 it("reject button has expected text", async () => {
   await act(async () => {
     render(
-      <AppContext.Provider value={(global as any).Hippo}>
-        <ModalProvider>
-          <MemoryRouter>
-            <ApproveAccounts />
-          </MemoryRouter>
-        </ModalProvider>
-      </AppContext.Provider>,
+      <MemoryRouter initialEntries={[approveUrl]}>
+        <App />
+      </MemoryRouter>,
       container
     );
   });
@@ -135,13 +117,9 @@ it("reject button has expected text", async () => {
 it("table header has expected text", async () => {
   await act(async () => {
     render(
-      <AppContext.Provider value={(global as any).Hippo}>
-        <ModalProvider>
-          <MemoryRouter>
-            <ApproveAccounts />
-          </MemoryRouter>
-        </ModalProvider>
-      </AppContext.Provider>,
+      <MemoryRouter initialEntries={[approveUrl]}>
+        <App />
+      </MemoryRouter>,
       container
     );
   });
@@ -154,13 +132,9 @@ it("table header has expected text", async () => {
 xit("displays dialog when reject is clicked", async () => {
   await act(async () => {
     render(
-      <AppContext.Provider value={(global as any).Hippo}>
-        <ModalProvider>
-          <MemoryRouter>
-            <ApproveAccounts />
-          </MemoryRouter>
-        </ModalProvider>
-      </AppContext.Provider>,
+      <MemoryRouter initialEntries={[approveUrl]}>
+        <App />
+      </MemoryRouter>,
       container
     );
   });
@@ -175,51 +149,53 @@ xit("displays dialog when reject is clicked", async () => {
   expect(container.querySelector("div.modal-dialog")).toBeTruthy();
 });
 
-it("calls approve and filters list when approve is clicked", async () => {
-  await act(async () => {
-    render(
-      <AppContext.Provider value={(global as any).Hippo}>
-        <ModalProvider>
-          <MemoryRouter>
-            <ApproveAccounts />
-          </MemoryRouter>
-        </ModalProvider>
-      </AppContext.Provider>,
-      container
-    );
-  });
-  expect(container.textContent).toContain(
-    "There are 2 account(s) awaiting your approval"
-  );
-  //console.log(container.innerHTML);
-  const approveButton = container.querySelector(
-    "button.btn.btn-primary"
-  ) as HTMLButtonElement;
-  expect(approveButton).toBeTruthy();
-  await act(async () => {
-    Simulate.click(approveButton);
-  });
-  //console.log(container.innerHTML);
-  expect(container.textContent).toContain(
-    "There are 1 account(s) awaiting your approval"
-  );
+// it("calls approve and filters list when approve is clicked", async () => {
+//   await act(async () => {
+//     render(
+//       <MemoryRouter initialEntries={[approveUrl]}>
+//         <App />
+//       </MemoryRouter>,
+//       container
+//     );
+//   });
+//   expect(container.textContent).toContain(
+//     "There are 2 account(s) awaiting your approval"
+//   );
+//   //console.log(container.innerHTML);
+//   const approveButton = container.querySelector(
+//     "button.btn.btn-primary"
+//   ) as HTMLButtonElement;
+//   expect(approveButton).toBeTruthy();
+//   await act(async () => {
+//     Simulate.click(approveButton);
+//   });
+//   //console.log(container.innerHTML);
+//   expect(container.textContent).toContain(
+//     "There are 1 account(s) awaiting your approval"
+//   );
 
-  expect(global.fetch).toHaveBeenCalledTimes(2);
-  expect(global.fetch).toHaveBeenCalledWith(`/api/${testCluster}/account/pending`, {
-    credentials: "include",
-    headers: {
-      Accept: "application/json",
-      "Content-Type": "application/json",
-      RequestVerificationToken: "fakeAntiForgeryToken",
-    },
-  });
-  expect(global.fetch).toHaveBeenLastCalledWith(`/api/${testCluster}/account/approve/1`, {
-    credentials: "include",
-    headers: {
-      Accept: "application/json",
-      "Content-Type": "application/json",
-      RequestVerificationToken: "fakeAntiForgeryToken",
-    },
-    method: "POST",
-  });
-});
+//   expect(global.fetch).toHaveBeenCalledTimes(2);
+//   expect(global.fetch).toHaveBeenCalledWith(
+//     `/api/${testCluster}/account/pending`,
+//     {
+//       credentials: "include",
+//       headers: {
+//         Accept: "application/json",
+//         "Content-Type": "application/json",
+//         RequestVerificationToken: "fakeAntiForgeryToken",
+//       },
+//     }
+//   );
+//   expect(global.fetch).toHaveBeenLastCalledWith(
+//     `/api/${testCluster}/account/approve/1`,
+//     {
+//       credentials: "include",
+//       headers: {
+//         Accept: "application/json",
+//         "Content-Type": "application/json",
+//         RequestVerificationToken: "fakeAntiForgeryToken",
+//       },
+//       method: "POST",
+//     }
+//   );
+// });

--- a/Hippo.Web/ClientApp/src/components/Account/ApproveAccounts.test.tsx
+++ b/Hippo.Web/ClientApp/src/components/Account/ApproveAccounts.test.tsx
@@ -1,15 +1,15 @@
 import React from "react";
 import { render, unmountComponentAtNode } from "react-dom";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Route } from "react-router-dom";
 
 import { fakeAccounts, fakeAppContext } from "../../test/mockData";
 import { responseMap } from "../../test/testHelpers";
 
 import { act, Simulate } from "react-dom/test-utils";
 
-import AppContext from "../../Shared/AppContext";
-import { ModalProvider } from "react-modal-hook";
 import App from "../../App";
+import { ApproveAccounts } from "./ApproveAccounts";
+import { ModalProvider } from "react-modal-hook";
 
 const testCluster = fakeAccounts[0].cluster;
 const approveUrl = `/${testCluster}/approve`;
@@ -149,53 +149,57 @@ xit("displays dialog when reject is clicked", async () => {
   expect(container.querySelector("div.modal-dialog")).toBeTruthy();
 });
 
-// it("calls approve and filters list when approve is clicked", async () => {
-//   await act(async () => {
-//     render(
-//       <MemoryRouter initialEntries={[approveUrl]}>
-//         <App />
-//       </MemoryRouter>,
-//       container
-//     );
-//   });
-//   expect(container.textContent).toContain(
-//     "There are 2 account(s) awaiting your approval"
-//   );
-//   //console.log(container.innerHTML);
-//   const approveButton = container.querySelector(
-//     "button.btn.btn-primary"
-//   ) as HTMLButtonElement;
-//   expect(approveButton).toBeTruthy();
-//   await act(async () => {
-//     Simulate.click(approveButton);
-//   });
-//   //console.log(container.innerHTML);
-//   expect(container.textContent).toContain(
-//     "There are 1 account(s) awaiting your approval"
-//   );
+it("calls approve and filters list when approve is clicked", async () => {
+  await act(async () => {
+    render(
+      <MemoryRouter initialEntries={[approveUrl]}>
+        <ModalProvider>
+          <Route path={"/:cluster/approve"}>
+            <ApproveAccounts />
+          </Route>
+        </ModalProvider>
+      </MemoryRouter>,
+      container
+    );
+  });
+  expect(container.textContent).toContain(
+    "There are 2 account(s) awaiting your approval"
+  );
+  //console.log(container.innerHTML);
+  const approveButton = container.querySelector(
+    "button.btn.btn-primary"
+  ) as HTMLButtonElement;
+  expect(approveButton).toBeTruthy();
+  await act(async () => {
+    Simulate.click(approveButton);
+  });
+  //console.log(container.innerHTML);
+  expect(container.textContent).toContain(
+    "There are 1 account(s) awaiting your approval"
+  );
 
-//   expect(global.fetch).toHaveBeenCalledTimes(2);
-//   expect(global.fetch).toHaveBeenCalledWith(
-//     `/api/${testCluster}/account/pending`,
-//     {
-//       credentials: "include",
-//       headers: {
-//         Accept: "application/json",
-//         "Content-Type": "application/json",
-//         RequestVerificationToken: "fakeAntiForgeryToken",
-//       },
-//     }
-//   );
-//   expect(global.fetch).toHaveBeenLastCalledWith(
-//     `/api/${testCluster}/account/approve/1`,
-//     {
-//       credentials: "include",
-//       headers: {
-//         Accept: "application/json",
-//         "Content-Type": "application/json",
-//         RequestVerificationToken: "fakeAntiForgeryToken",
-//       },
-//       method: "POST",
-//     }
-//   );
-// });
+  expect(global.fetch).toHaveBeenCalledTimes(2);
+  expect(global.fetch).toHaveBeenCalledWith(
+    `/api/${testCluster}/account/pending`,
+    {
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        RequestVerificationToken: "fakeAntiForgeryToken",
+      },
+    }
+  );
+  expect(global.fetch).toHaveBeenLastCalledWith(
+    `/api/${testCluster}/account/approve/1`,
+    {
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        RequestVerificationToken: "fakeAntiForgeryToken",
+      },
+      method: "POST",
+    }
+  );
+});

--- a/Hippo.Web/ClientApp/src/components/Account/ApproveAccounts.tsx
+++ b/Hippo.Web/ClientApp/src/components/Account/ApproveAccounts.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from "react";
-import { Account } from "../../types";
+import { Account, IRouteParams } from "../../types";
 import { RejectRequest } from "../../Shared/RejectRequest";
 import { authenticatedFetch } from "../../util/api";
 import { usePromiseNotification } from "../../util/Notifications";
+import { useParams } from "react-router-dom";
 
 export const ApproveAccounts = () => {
   // get all accounts that need approval and list them
@@ -12,9 +13,11 @@ export const ApproveAccounts = () => {
   const [accountApproving, setAccountApproving] = useState<number>();
   const [notification, setNotification] = usePromiseNotification();
 
+  const { cluster } = useParams<IRouteParams>();
+
   useEffect(() => {
     const fetchAccounts = async () => {
-      const response = await authenticatedFetch("/api/account/pending");
+      const response = await authenticatedFetch(`/api/${cluster}/account/pending`);
 
       if (response.ok) {
         setAccounts(await response.json());
@@ -22,12 +25,12 @@ export const ApproveAccounts = () => {
     };
 
     fetchAccounts();
-  }, []);
+  }, [cluster]);
 
   const handleApprove = async (account: Account) => {
     setAccountApproving(account.id);
 
-    const req = authenticatedFetch(`/api/account/approve/${account.id}`, {
+    const req = authenticatedFetch(`/api/${cluster}/account/approve/${account.id}`, {
       method: "POST",
     });
 
@@ -85,7 +88,7 @@ export const ApproveAccounts = () => {
                       <RejectRequest
                         account={account}
                         removeAccount={() => handleReject(account)}
-                        updateUrl={"/api/Account/Reject/"}
+                        updateUrl={`/api/${cluster}/Account/Reject/`}
                         disabled={notification.pending}
                       ></RejectRequest>
                     )}

--- a/Hippo.Web/ClientApp/src/components/Account/Multiple.tsx
+++ b/Hippo.Web/ClientApp/src/components/Account/Multiple.tsx
@@ -9,7 +9,7 @@ export const Multiple = () => {
     <div className="row justify-content-center">
       <div className="col-md-8">
         <p>
-          TODO TODO: You have multiple accounts, this will be implemented soon
+          TODO TODO: You have multiple accounts, this will be implemented soon.  For now, please use /caesfarm
         </p>
         <ul>
           {accounts.map((account) => (

--- a/Hippo.Web/ClientApp/src/components/Account/Multiple.tsx
+++ b/Hippo.Web/ClientApp/src/components/Account/Multiple.tsx
@@ -1,0 +1,22 @@
+import { useContext } from "react";
+import AppContext from "../../Shared/AppContext";
+
+// Handle redirection for people with multiple accounts
+export const Multiple = () => {
+  const [{ accounts }] = useContext(AppContext);
+
+  return (
+    <div className="row justify-content-center">
+      <div className="col-md-8">
+        <p>
+          TODO TODO: You have multiple accounts, this will be implemented soon
+        </p>
+        <ul>
+          {accounts.map((account) => (
+            <li key={account.cluster}>{account.cluster}</li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+};

--- a/Hippo.Web/ClientApp/src/components/Account/RequestForm.tsx
+++ b/Hippo.Web/ClientApp/src/components/Account/RequestForm.tsx
@@ -72,7 +72,7 @@ export const RequestForm = () => {
           <span className="status-color">{context.user.detail.firstName}</span>
         </h3>
         <p>
-          You don't seem to have an account on Farm yet. If you'd like access,
+          You don't seem to have an account on the {cluster} cluster yet. If you'd like access,
           please answer the&nbsp;questions&nbsp;below
         </p>
         <hr />

--- a/Hippo.Web/ClientApp/src/components/Account/RequestForm.tsx
+++ b/Hippo.Web/ClientApp/src/components/Account/RequestForm.tsx
@@ -53,7 +53,7 @@ export const RequestForm = () => {
 
     if (response.ok) {
       const newAccount = await response.json();
-      setContext((ctx) => ({ ...ctx, account: newAccount }));
+      setContext((ctx) => ({ ...ctx, accounts: [...ctx.accounts, newAccount] }));
       history.replace("/"); // could also push straight to pending, but home will redirect there immediately anyway
     }
   };

--- a/Hippo.Web/ClientApp/src/components/Account/RequestForm.tsx
+++ b/Hippo.Web/ClientApp/src/components/Account/RequestForm.tsx
@@ -1,8 +1,8 @@
 import { useContext, useEffect, useState } from "react";
 import "react-bootstrap-typeahead/css/Typeahead.css";
-import { useHistory } from "react-router-dom";
+import { useHistory, useParams } from "react-router-dom";
 import AppContext from "../../Shared/AppContext";
-import { Account, RequestPostModel } from "../../types";
+import { Account, IRouteParams, RequestPostModel } from "../../types";
 import { authenticatedFetch } from "../../util/api";
 import { Typeahead } from "react-bootstrap-typeahead";
 import { usePromiseNotification } from "../../util/Notifications";
@@ -18,11 +18,14 @@ export const RequestForm = () => {
   });
 
   const history = useHistory();
+  const { cluster } = useParams<IRouteParams>();
 
   // load up possible sponsors
   useEffect(() => {
     const fetchSponsors = async () => {
-      const response = await authenticatedFetch("/api/account/sponsors");
+      const response = await authenticatedFetch(
+        `/api/${cluster}/account/sponsors`
+      );
 
       const sponsorResult = await response.json();
 
@@ -32,10 +35,10 @@ export const RequestForm = () => {
     };
 
     fetchSponsors();
-  }, []);
+  }, [cluster]);
 
   const handleSubmit = async () => {
-    const req = authenticatedFetch("/api/account/create", {
+    const req = authenticatedFetch(`/api/${cluster}/account/create`, {
       method: "POST",
       body: JSON.stringify(request),
     });
@@ -53,7 +56,10 @@ export const RequestForm = () => {
 
     if (response.ok) {
       const newAccount = await response.json();
-      setContext((ctx) => ({ ...ctx, accounts: [...ctx.accounts, newAccount] }));
+      setContext((ctx) => ({
+        ...ctx,
+        accounts: [...ctx.accounts, newAccount],
+      }));
       history.replace("/"); // could also push straight to pending, but home will redirect there immediately anyway
     }
   };

--- a/Hippo.Web/ClientApp/src/components/Account/RequestForm.tsx
+++ b/Hippo.Web/ClientApp/src/components/Account/RequestForm.tsx
@@ -60,7 +60,7 @@ export const RequestForm = () => {
         ...ctx,
         accounts: [...ctx.accounts, newAccount],
       }));
-      history.replace("/"); // could also push straight to pending, but home will redirect there immediately anyway
+      history.replace(`/${cluster}/pendingapproval`);
     }
   };
 

--- a/Hippo.Web/ClientApp/src/components/Account/SponsoredAccounts.tsx
+++ b/Hippo.Web/ClientApp/src/components/Account/SponsoredAccounts.tsx
@@ -1,13 +1,16 @@
 import { useEffect, useState } from "react";
-import { Account } from "../../types";
+import { useParams } from "react-router-dom";
+import { Account, IRouteParams } from "../../types";
 import { authenticatedFetch } from "../../util/api";
 
 export const SponsoredAccounts = () => {
   const [accounts, setAccounts] = useState<Account[]>();
 
+  const { cluster } = useParams<IRouteParams>();
+
   useEffect(() => {
     const fetchAccounts = async () => {
-      const response = await authenticatedFetch("/api/account/sponsored");
+      const response = await authenticatedFetch(`/api/${cluster}/account/sponsored`);
 
       if (response.ok) {
         setAccounts(await response.json());
@@ -15,7 +18,7 @@ export const SponsoredAccounts = () => {
     };
 
     fetchAccounts();
-  }, []);
+  }, [cluster]);
 
   if (accounts === undefined) {
     return (

--- a/Hippo.Web/ClientApp/src/components/Admin/AdminApproveAccounts.tsx
+++ b/Hippo.Web/ClientApp/src/components/Admin/AdminApproveAccounts.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from "react";
-import { Account } from "../../types";
+import { Account, IRouteParams } from "../../types";
 import { authenticatedFetch } from "../../util/api";
 import { RejectRequest } from "../../Shared/RejectRequest";
 import { usePromiseNotification } from "../../util/Notifications";
+import { useParams } from "react-router-dom";
 
 export const AdminApproveAccounts = () => {
   // get all accounts that need approval and list them
@@ -12,9 +13,11 @@ export const AdminApproveAccounts = () => {
   const [accountApproving, setAccountApproving] = useState<number>();
   const [notification, setNotification] = usePromiseNotification();
 
+  const { cluster } = useParams<IRouteParams>();
+
   useEffect(() => {
     const fetchAccounts = async () => {
-      const response = await authenticatedFetch("/api/admin/pending");
+      const response = await authenticatedFetch(`/api/${cluster}/admin/pending`);
 
       if (response.ok) {
         setAccounts(await response.json());
@@ -22,12 +25,12 @@ export const AdminApproveAccounts = () => {
     };
 
     fetchAccounts();
-  }, []);
+  }, [cluster]);
 
   const handleApprove = async (account: Account) => {
     setAccountApproving(account.id);
 
-    const req = authenticatedFetch(`/api/admin/approve/${account.id}`, {
+    const req = authenticatedFetch(`/api/${cluster}/admin/approve/${account.id}`, {
       method: "POST",
     });
 
@@ -92,7 +95,7 @@ export const AdminApproveAccounts = () => {
                     <RejectRequest
                       account={account}
                       removeAccount={() => handleReject(account)}
-                      updateUrl={"/api/admin/reject/"}
+                      updateUrl={`/api/${cluster}/admin/reject/`}
                       disabled={notification.pending}
                     ></RejectRequest>
                   </td>

--- a/Hippo.Web/ClientApp/src/components/Admin/AdminUsers.tsx
+++ b/Hippo.Web/ClientApp/src/components/Admin/AdminUsers.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
-import { User } from "../../types";
+import { useParams } from "react-router-dom";
+import { Account, IRouteParams } from "../../types";
 import { authenticatedFetch } from "../../util/api";
 import { usePromiseNotification } from "../../util/Notifications";
 
@@ -7,29 +8,30 @@ export const AdminUsers = () => {
   // get all accounts that need approval and list them
   // allow user to approve or reject each account
 
-  const [users, setUsers] = useState<User[]>();
+  const [accounts, setAccounts] = useState<Account[]>();
   const [adminRemoving, setAdminRemoving] = useState<number>();
   const [request, setRequest] = useState({
     id: "",
   });
+  const { cluster } = useParams<IRouteParams>();
   const [notification, setNotification] = usePromiseNotification();
 
   useEffect(() => {
-    const fetchAdminUsers = async () => {
-      const response = await authenticatedFetch("/api/admin/index");
+    const fetchAdminAccounts = async () => {
+      const response = await authenticatedFetch(`/api/${cluster}/admin/index`);
 
       if (response.ok) {
-        setUsers(await response.json());
+        setAccounts(await response.json());
       }
     };
 
-    fetchAdminUsers();
-  }, []);
+    fetchAdminAccounts();
+  }, [cluster]);
 
-  const handleRemove = async (user: User) => {
-    setAdminRemoving(user.id);
+  const handleRemove = async (account: Account) => {
+    setAdminRemoving(account.id);
 
-    const req = authenticatedFetch(`/api/admin/Remove/${user.id}`, {
+    const req = authenticatedFetch(`/api/${cluster}/admin/Remove/${account.id}`, {
       method: "POST",
     });
 
@@ -46,13 +48,13 @@ export const AdminUsers = () => {
 
     if (response.ok) {
       // remove the user from the list
-      setUsers(users?.filter((a) => a.id !== user.id));
+      setAccounts(accounts?.filter((a) => a.id !== account.id));
     }
     setAdminRemoving(undefined);
   };
 
   const handleSubmit = async () => {
-    const req = authenticatedFetch(`/api/admin/create/${request.id}`, {
+    const req = authenticatedFetch(`/api/${cluster}/admin/create/${request.id}`, {
       method: "POST",
     });
 
@@ -67,14 +69,14 @@ export const AdminUsers = () => {
     const response = await req;
 
     if (response.ok) {
-      const newUser = await response.json();
+      const newAccount = await response.json();
       //Add the user to the list
-      setUsers((r) => (r ? [...r, newUser] : [newUser]));
+      setAccounts((r) => (r ? [...r, newAccount] : [newAccount]));
       setRequest((r) => ({ ...r, id: "" }));
     }
   };
 
-  if (users === undefined) {
+  if (accounts === undefined) {
     return (
       <div className="row justify-content-center">
         <div className="col-md-8">Loading...</div>
@@ -107,7 +109,7 @@ export const AdminUsers = () => {
           </button>
           <hr />
 
-          <p>There are {users.length} users with admin access</p>
+          <p>There are {accounts.length} users with admin access</p>
           <table className="table">
             <thead>
               <tr>
@@ -117,17 +119,17 @@ export const AdminUsers = () => {
               </tr>
             </thead>
             <tbody>
-              {users.map((user) => (
-                <tr key={user.id}>
-                  <td>{user.name}</td>
-                  <td>{user.email}</td>
+              {accounts.map((account) => (
+                <tr key={account.id}>
+                  <td>{account.owner?.name}</td>
+                  <td>{account.owner?.email}</td>
                   <td>
                     <button
                       disabled={notification.pending}
-                      onClick={() => handleRemove(user)}
+                      onClick={() => handleRemove(account)}
                       className="btn btn-primary"
                     >
-                      {adminRemoving === user.id ? "Removing..." : "Remove"}
+                      {adminRemoving === account.id ? "Removing..." : "Remove"}
                     </button>
                   </td>
                 </tr>

--- a/Hippo.Web/ClientApp/src/components/Admin/Sponsors.tsx
+++ b/Hippo.Web/ClientApp/src/components/Admin/Sponsors.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
-import { Account, CreateSponsorPostModel } from "../../types";
+import { useParams } from "react-router-dom";
+import { Account, CreateSponsorPostModel, IRouteParams } from "../../types";
 import { authenticatedFetch } from "../../util/api";
 import { usePromiseNotification } from "../../util/Notifications";
 
@@ -13,10 +14,11 @@ export const Sponsors = () => {
     lookup: "",
     name: "",
   });
+  const { cluster } = useParams<IRouteParams>();
 
   useEffect(() => {
     const fetchSponsors = async () => {
-      const response = await authenticatedFetch("/api/admin/sponsors");
+      const response = await authenticatedFetch(`/api/${cluster}/admin/sponsors`);
 
       if (response.ok) {
         setAccounts(await response.json());
@@ -26,12 +28,12 @@ export const Sponsors = () => {
     };
 
     fetchSponsors();
-  }, []);
+  }, [cluster]);
 
   const handleRemove = async (account: Account) => {
     setAdminRemoving(account.id);
 
-    const req = authenticatedFetch(`/api/admin/RemoveSponsor/${account.id}`, {
+    const req = authenticatedFetch(`/api/${cluster}/admin/RemoveSponsor/${account.id}`, {
       method: "POST",
     });
 
@@ -48,7 +50,7 @@ export const Sponsors = () => {
   };
 
   const handleSubmit = async () => {
-    const req = authenticatedFetch("/api/admin/createSponsor", {
+    const req = authenticatedFetch(`/api/${cluster}/admin/createSponsor`, {
       method: "POST",
       body: JSON.stringify(request),
     });

--- a/Hippo.Web/ClientApp/src/components/Home.test.tsx
+++ b/Hippo.Web/ClientApp/src/components/Home.test.tsx
@@ -4,9 +4,7 @@ import { MemoryRouter } from "react-router-dom";
 import App from "../App";
 import {
   fakeAccounts,
-  fakeAdminAppContext,
   fakeAppContext,
-  fakeAdminUsers,
   fakeAppContextNoAccount,
 } from "../test/mockData";
 import { responseMap } from "../test/testHelpers";
@@ -35,53 +33,6 @@ describe("Basic render", () => {
         div
       );
     });
-
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-  });
-});
-
-describe("Home Redirect when Admin", () => {
-  beforeEach(() => {
-    const adminUsersResponse = Promise.resolve({
-      status: 200,
-      ok: true,
-      json: () => Promise.resolve(fakeAdminUsers),
-    });
-
-    (global as any).Hippo = fakeAdminAppContext;
-
-    global.fetch = jest.fn().mockImplementation((x) =>
-      responseMap(x, {
-        [`/api/${fakeAdminAppContext.accounts[0].cluster}/admin/index`]:
-          adminUsersResponse,
-      })
-    );
-  });
-  it("renders without crashing", async () => {
-    const div = document.createElement("div");
-    await act(async () => {
-      ReactDOM.render(
-        <MemoryRouter>
-          <App />
-        </MemoryRouter>,
-        div
-      );
-    });
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-  });
-
-  it("Redirects to AdminUsers", async () => {
-    const div = document.createElement("div");
-    await act(async () => {
-      ReactDOM.render(
-        <MemoryRouter>
-          <App />
-        </MemoryRouter>,
-        div
-      );
-    });
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-    expect(div.textContent).toContain("There are 2 users with admin access");
   });
 });
 
@@ -89,6 +40,7 @@ describe("Home Redirect when Sponsor", () => {
   beforeEach(() => {
     (global as any).Hippo = fakeAppContext;
   });
+
   it("renders without crashing", async () => {
     const div = document.createElement("div");
     await act(async () => {
@@ -99,7 +51,6 @@ describe("Home Redirect when Sponsor", () => {
         div
       );
     });
-    await new Promise((resolve) => setTimeout(resolve, 1000));
   });
 
   it("Shows welcome message", async () => {
@@ -112,9 +63,8 @@ describe("Home Redirect when Sponsor", () => {
         div
       );
     });
-    await new Promise((resolve) => setTimeout(resolve, 1000));
     expect(div.textContent).toContain(
-      "Welcome Bob you already have an account, enjoy farm"
+      "Welcome Bob you already have an account"
     );
   });
 
@@ -128,7 +78,6 @@ describe("Home Redirect when Sponsor", () => {
         div
       );
     });
-    await new Promise((resolve) => setTimeout(resolve, 1000));
     expect(div.textContent).toContain("Pending Approvals");
   });
 });
@@ -159,7 +108,6 @@ describe("Home Redirect no account", () => {
         div
       );
     });
-    await new Promise((resolve) => setTimeout(resolve, 1000));
   });
 
   it("Shows welcome message", async () => {
@@ -172,7 +120,6 @@ describe("Home Redirect no account", () => {
         div
       );
     });
-    await new Promise((resolve) => setTimeout(resolve, 1000));
     expect(div.textContent).toContain("Welcome, Bob");
     expect(div.textContent).toContain(
       "You don't seem to have an account on Farm yet."
@@ -189,7 +136,6 @@ describe("Home Redirect no account", () => {
         div
       );
     });
-    await new Promise((resolve) => setTimeout(resolve, 1000));
     expect(div.textContent).not.toContain("Pending Approvals");
   });
 });

--- a/Hippo.Web/ClientApp/src/components/Home.test.tsx
+++ b/Hippo.Web/ClientApp/src/components/Home.test.tsx
@@ -122,7 +122,7 @@ describe("Home Redirect no account", () => {
     });
     expect(div.textContent).toContain("Welcome, Bob");
     expect(div.textContent).toContain(
-      "You don't seem to have an account on Farm yet."
+      "You don't seem to have an account"
     );
   });
 

--- a/Hippo.Web/ClientApp/src/components/Home.test.tsx
+++ b/Hippo.Web/ClientApp/src/components/Home.test.tsx
@@ -22,19 +22,7 @@ afterEach(() => {
 
 describe("Basic render", () => {
   beforeEach(() => {
-    const accountResponse = Promise.resolve({
-      status: 200,
-      ok: true,
-      json: () => Promise.resolve(fakeAccounts[0]),
-    });
-
     (global as any).Hippo = fakeAppContext;
-
-    global.fetch = jest.fn().mockImplementation((x) =>
-      responseMap(x, {
-        "/api/account/get": accountResponse,
-      })
-    );
   });
 
   it("renders without crashing", async () => {
@@ -54,12 +42,6 @@ describe("Basic render", () => {
 
 describe("Home Redirect when Admin", () => {
   beforeEach(() => {
-    const accountResponse = Promise.resolve({
-      status: 200,
-      ok: true,
-      json: () => Promise.resolve(fakeAccounts[0]),
-    });
-
     const adminUsersResponse = Promise.resolve({
       status: 200,
       ok: true,
@@ -70,8 +52,8 @@ describe("Home Redirect when Admin", () => {
 
     global.fetch = jest.fn().mockImplementation((x) =>
       responseMap(x, {
-        "/api/account/get": accountResponse,
-        "/api/admin/index": adminUsersResponse,
+        [`/api/${fakeAdminAppContext.accounts[0].cluster}/admin/index`]:
+          adminUsersResponse,
       })
     );
   });
@@ -105,19 +87,7 @@ describe("Home Redirect when Admin", () => {
 
 describe("Home Redirect when Sponsor", () => {
   beforeEach(() => {
-    const accountResponse = Promise.resolve({
-      status: 200,
-      ok: true,
-      json: () => Promise.resolve(fakeAccounts[0]),
-    });
-
     (global as any).Hippo = fakeAppContext;
-
-    global.fetch = jest.fn().mockImplementation((x) =>
-      responseMap(x, {
-        "/api/account/get": accountResponse,
-      })
-    );
   });
   it("renders without crashing", async () => {
     const div = document.createElement("div");
@@ -165,12 +135,6 @@ describe("Home Redirect when Sponsor", () => {
 
 describe("Home Redirect no account", () => {
   beforeEach(() => {
-    const accountResponse = Promise.resolve({
-      status: 204, // no content
-      ok: true,
-      json: () => Promise.resolve(fakeAccounts[0]),
-    });
-
     const sponsorsResponse = Promise.resolve({
       status: 200,
       ok: true,
@@ -181,8 +145,7 @@ describe("Home Redirect no account", () => {
 
     global.fetch = jest.fn().mockImplementation((x) =>
       responseMap(x, {
-        "/api/account/get": accountResponse,
-        "/api/account/sponsors": sponsorsResponse,
+        [`/api/${fakeAccounts[0].cluster}/account/sponsors`]: sponsorsResponse,
       })
     );
   });

--- a/Hippo.Web/ClientApp/src/components/Home.tsx
+++ b/Hippo.Web/ClientApp/src/components/Home.tsx
@@ -8,7 +8,8 @@ export const Home = () => {
 
   if (accounts.length === 0) {
     // no accounts, show request form
-    return <Redirect to="/create" />;
+    // TODO: default to caesfarm, since it's the only one.  eventually build a dropdown or route through cluster selection
+    return <Redirect to="/caesfarm/create" />;
   } else if (accounts.length === 1) {
     // one account, show page depending on status
     return (

--- a/Hippo.Web/ClientApp/src/components/Home.tsx
+++ b/Hippo.Web/ClientApp/src/components/Home.tsx
@@ -4,10 +4,19 @@ import AppContext from "../Shared/AppContext";
 
 // redirect to the proper page depending on current account status
 export const Home = () => {
-  const [{ account, user }] = useContext(AppContext);
-  if (user?.detail?.isAdmin) {
-    return <Redirect to="/admin/users" />;
-  }
+  const [{ accounts }] = useContext(AppContext);
 
-  return <Redirect to={`/${account.status.toLocaleLowerCase()}`} />;
+  if (accounts.length === 0) {
+    // no accounts, show request form
+    return <Redirect to="/create" />;
+  } else if (accounts.length === 1) {
+    // one account, show page depending on status
+    return (
+      <Redirect
+        to={`/${accounts[0].cluster}/${accounts[0].status.toLocaleLowerCase()}`}
+      />
+    );
+  } else {
+    return <Redirect to="/multiple" />;
+  }
 };

--- a/Hippo.Web/ClientApp/src/test/mockData.ts
+++ b/Hippo.Web/ClientApp/src/test/mockData.ts
@@ -32,17 +32,7 @@ export const fakeAccounts: Account[] = [
     createdOn: "2020-01-01T00:00:00.000Z",
     updatedOn: "2020-01-01T00:00:00.000Z",
     isAdmin: false,
-  },
-  {
-    id: 2,
-    name: "Account 2",
-    status: "Active",
-    canSponsor: true,
-    cluster: "caesfarm",
-    createdOn: "2020-01-01T00:00:00.000Z",
-    updatedOn: "2020-01-01T00:00:00.000Z",
-    isAdmin: false,
-  },
+  }
 ];
 
 export const fakeAppContext: AppContextShape = {

--- a/Hippo.Web/ClientApp/src/test/mockData.ts
+++ b/Hippo.Web/ClientApp/src/test/mockData.ts
@@ -86,16 +86,5 @@ export const fakeAppContextNoAccount: AppContextShape = {
       ...fakeUser,
     },
   },
-  accounts: [
-    {
-      id: 3,
-      name: "Account 3",
-      status: "Create",
-      canSponsor: false,
-      cluster: "caesfarm",
-      createdOn: "2020-01-01T00:00:00.000Z",
-      updatedOn: "2020-01-01T00:00:00.000Z",
-      isAdmin: false,
-    },
-  ],
+  accounts: [],
 };

--- a/Hippo.Web/ClientApp/src/test/mockData.ts
+++ b/Hippo.Web/ClientApp/src/test/mockData.ts
@@ -32,7 +32,17 @@ export const fakeAccounts: Account[] = [
     createdOn: "2020-01-01T00:00:00.000Z",
     updatedOn: "2020-01-01T00:00:00.000Z",
     isAdmin: false,
-  }
+  },
+  {
+    id: 2,
+    name: "Account 2",
+    status: "Active",
+    canSponsor: true,
+    cluster: "caesfarm",
+    createdOn: "2020-01-01T00:00:00.000Z",
+    updatedOn: "2020-01-01T00:00:00.000Z",
+    isAdmin: false,
+  },
 ];
 
 export const fakeAppContext: AppContextShape = {
@@ -42,7 +52,7 @@ export const fakeAppContext: AppContextShape = {
       ...fakeUser,
     },
   },
-  accounts: fakeAccounts,
+  accounts: [fakeAccounts[0]],
 };
 
 export const fakeAdminAppContext: AppContextShape = {
@@ -52,7 +62,7 @@ export const fakeAdminAppContext: AppContextShape = {
       ...fakeAdminUser,
     },
   },
-  accounts: fakeAccounts,
+  accounts: [fakeAccounts[0]],
 };
 
 export const fakeAdminUsers: User[] = [

--- a/Hippo.Web/ClientApp/src/test/mockData.ts
+++ b/Hippo.Web/ClientApp/src/test/mockData.ts
@@ -31,6 +31,7 @@ export const fakeAccounts: Account[] = [
     cluster: "caesfarm",
     createdOn: "2020-01-01T00:00:00.000Z",
     updatedOn: "2020-01-01T00:00:00.000Z",
+    isAdmin: false,
   },
   {
     id: 2,
@@ -40,6 +41,7 @@ export const fakeAccounts: Account[] = [
     cluster: "caesfarm",
     createdOn: "2020-01-01T00:00:00.000Z",
     updatedOn: "2020-01-01T00:00:00.000Z",
+    isAdmin: false,
   },
 ];
 
@@ -84,13 +86,16 @@ export const fakeAppContextNoAccount: AppContextShape = {
       ...fakeUser,
     },
   },
-  accounts: [{
-    id: 3,
-    name: "Account 3",
-    status: "Create",
-    canSponsor: false,
-    cluster: "caesfarm",
-    createdOn: "2020-01-01T00:00:00.000Z",
-    updatedOn: "2020-01-01T00:00:00.000Z",
-  }],
+  accounts: [
+    {
+      id: 3,
+      name: "Account 3",
+      status: "Create",
+      canSponsor: false,
+      cluster: "caesfarm",
+      createdOn: "2020-01-01T00:00:00.000Z",
+      updatedOn: "2020-01-01T00:00:00.000Z",
+      isAdmin: false,
+    },
+  ],
 };

--- a/Hippo.Web/ClientApp/src/test/mockData.ts
+++ b/Hippo.Web/ClientApp/src/test/mockData.ts
@@ -28,6 +28,7 @@ export const fakeAccounts: Account[] = [
     name: "Account 1",
     status: "Active",
     canSponsor: true,
+    cluster: "caesfarm",
     createdOn: "2020-01-01T00:00:00.000Z",
     updatedOn: "2020-01-01T00:00:00.000Z",
   },
@@ -36,6 +37,7 @@ export const fakeAccounts: Account[] = [
     name: "Account 2",
     status: "Active",
     canSponsor: true,
+    cluster: "caesfarm",
     createdOn: "2020-01-01T00:00:00.000Z",
     updatedOn: "2020-01-01T00:00:00.000Z",
   },
@@ -48,7 +50,7 @@ export const fakeAppContext: AppContextShape = {
       ...fakeUser,
     },
   },
-  account: fakeAccounts[0],
+  accounts: fakeAccounts,
 };
 
 export const fakeAdminAppContext: AppContextShape = {
@@ -58,7 +60,7 @@ export const fakeAdminAppContext: AppContextShape = {
       ...fakeAdminUser,
     },
   },
-  account: fakeAccounts[0],
+  accounts: fakeAccounts,
 };
 
 export const fakeAdminUsers: User[] = [
@@ -82,12 +84,13 @@ export const fakeAppContextNoAccount: AppContextShape = {
       ...fakeUser,
     },
   },
-  account: {
+  accounts: [{
     id: 3,
     name: "Account 3",
     status: "Create",
     canSponsor: false,
+    cluster: "caesfarm",
     createdOn: "2020-01-01T00:00:00.000Z",
     updatedOn: "2020-01-01T00:00:00.000Z",
-  },
+  }],
 };

--- a/Hippo.Web/ClientApp/src/types.ts
+++ b/Hippo.Web/ClientApp/src/types.ts
@@ -17,6 +17,7 @@ export interface Account {
   status: string;
   canSponsor: boolean;
   createdOn: string;
+  cluster: string;
   owner?: User;
   sponsor?: Account;
   updatedOn: string;
@@ -37,7 +38,7 @@ export interface AppContextShape {
   user: {
     detail: User;
   };
-  account: Account;
+  accounts: Account[];
 }
 
 export interface PromiseStatus {

--- a/Hippo.Web/ClientApp/src/types.ts
+++ b/Hippo.Web/ClientApp/src/types.ts
@@ -21,6 +21,7 @@ export interface Account {
   owner?: User;
   sponsor?: Account;
   updatedOn: string;
+  isAdmin: boolean;
 }
 
 export interface RequestPostModel {

--- a/Hippo.Web/ClientApp/src/types.ts
+++ b/Hippo.Web/ClientApp/src/types.ts
@@ -45,3 +45,7 @@ export interface PromiseStatus {
   pending: boolean;
   success: boolean;
 }
+
+export interface IRouteParams {
+  cluster: string;
+}

--- a/Hippo.Web/Controllers/AccountController.cs
+++ b/Hippo.Web/Controllers/AccountController.cs
@@ -1,6 +1,7 @@
 using Hippo.Core.Data;
 using Hippo.Core.Domain;
 using Hippo.Core.Services;
+using Hippo.Web.Extensions;
 using Hippo.Web.Models;
 using Hippo.Web.Services;
 using Microsoft.AspNetCore.Authorization;
@@ -32,17 +33,17 @@ public class AccountController : SuperController
 
     // Return account info for the currently logged in user
     [HttpGet]
-    public async Task<ActionResult> Get()
+    public async Task<ActionResult> Get(string cluster)
     {
         var currentUser = await _userService.GetCurrentUser();
 
-        return Ok(await _dbContext.Accounts.AsNoTracking().SingleOrDefaultAsync(a => a.Owner.Iam == currentUser.Iam));
+        return Ok(await _dbContext.Accounts.InCluster(Cluster).Where(a => a.Owner.Iam == currentUser.Iam).AsNoTracking().ToArrayAsync());
     }
 
     [HttpGet]
     public async Task<ActionResult> Sponsors()
     {
-        return Ok(await _dbContext.Accounts.Where(a => a.CanSponsor).AsNoTracking().OrderBy(a => a.Name).ToListAsync());
+        return Ok(await _dbContext.Accounts.InCluster(Cluster).Where(a => a.CanSponsor).AsNoTracking().OrderBy(a => a.Name).ToArrayAsync());
     }
 
     // Return all accounts that are waiting for the current user to approve
@@ -51,7 +52,7 @@ public class AccountController : SuperController
     {
         var currentUser = await _userService.GetCurrentUser();
         //Make this one order by date? Or stay consistent and just by name?
-        return Ok(await _dbContext.Accounts.Where(a => a.Sponsor.OwnerId == currentUser.Id && a.Status == Account.Statuses.PendingApproval).AsNoTracking().OrderBy(a => a.Name).ToListAsync());
+        return Ok(await _dbContext.Accounts.InCluster(Cluster).Where(a => a.Sponsor.OwnerId == currentUser.Id && a.Status == Account.Statuses.PendingApproval).AsNoTracking().OrderBy(a => a.Name).ToArrayAsync());
     }
 
     [HttpGet]
@@ -59,7 +60,7 @@ public class AccountController : SuperController
     {
         var currentUser = await _userService.GetCurrentUser();
 
-        return Ok(await _dbContext.Accounts.Where(a => a.Sponsor.OwnerId == currentUser.Id && a.Status != Account.Statuses.PendingApproval).AsNoTracking().OrderBy(a => a.Name).ToListAsync());
+        return Ok(await _dbContext.Accounts.InCluster(Cluster).Where(a => a.Sponsor.OwnerId == currentUser.Id && a.Status != Account.Statuses.PendingApproval).AsNoTracking().OrderBy(a => a.Name).ToArrayAsync());
     }
 
     // Approve a given pending account if you are the sponsor
@@ -68,14 +69,13 @@ public class AccountController : SuperController
     {
         var currentUser = await _userService.GetCurrentUser();
 
-        var account = await _dbContext.Accounts.Include(a => a.Owner).AsSingleQuery()
+        var account = await _dbContext.Accounts.InCluster(Cluster).Include(a => a.Owner).AsSingleQuery()
             .SingleOrDefaultAsync(a => a.Id == id && a.Sponsor.OwnerId == currentUser.Id && a.Status == Account.Statuses.PendingApproval);
 
         if (account == null)
         {
             return NotFound();
         }
-
 
         var tempFileName = $"/var/lib/remote-api/.{account.Owner.Kerberos}.txt"; //Leading .
         var fileName = $"/var/lib/remote-api/{account.Owner.Kerberos}.txt";
@@ -93,7 +93,6 @@ public class AccountController : SuperController
 
         await _historyService.AccountApproved(account);
 
-
         await _dbContext.SaveChangesAsync();
 
         return Ok();
@@ -109,15 +108,13 @@ public class AccountController : SuperController
 
         var currentUser = await _userService.GetCurrentUser();
 
-        var account = await _dbContext.Accounts.Include(a => a.Owner).AsSingleQuery()
+        var account = await _dbContext.Accounts.InCluster(Cluster).Include(a => a.Owner).AsSingleQuery()
             .SingleOrDefaultAsync(a => a.Id == id && a.Sponsor.OwnerId == currentUser.Id && a.Status == Account.Statuses.PendingApproval);
 
         if (account == null)
         {
             return NotFound();
         }
-
-
 
         account.Status = Account.Statuses.Rejected;
         account.IsActive = false;
@@ -166,7 +163,12 @@ public class AccountController : SuperController
             return BadRequest("Invalid SSH key");
         }
 
+        var cluster = await _dbContext.Clusters.SingleOrDefaultAsync(c => c.Name == Cluster);
 
+        if (cluster == null)
+        {
+            return BadRequest("Cluster not found");
+        }
 
         var account = new Account()
         {
@@ -176,6 +178,7 @@ public class AccountController : SuperController
             SshKey = await _yamlService.Get(currentUser, model),
             IsActive = true,
             Name = $"{currentUser.Name} ({currentUser.Email})",
+            ClusterId = cluster.Id,
             Status = Account.Statuses.PendingApproval,
         };
 
@@ -192,7 +195,4 @@ public class AccountController : SuperController
 
         return Ok(account);
     }
-
-
-
 }

--- a/Hippo.Web/Controllers/AdminController.cs
+++ b/Hippo.Web/Controllers/AdminController.cs
@@ -86,7 +86,7 @@ public class AdminController : SuperController
                 Owner = user,
                 IsAdmin = true,
                 IsActive = true,
-                Status = Account.Statuses.PendingApproval,
+                Status = Account.Statuses.Active,
                 ClusterId = (await _dbContext.Clusters.SingleAsync(c => c.Name == Cluster)).Id
             };
 

--- a/Hippo.Web/Controllers/AdminController.cs
+++ b/Hippo.Web/Controllers/AdminController.cs
@@ -2,6 +2,7 @@
 using Hippo.Core.Domain;
 using Hippo.Core.Models;
 using Hippo.Core.Services;
+using Hippo.Web.Extensions;
 using Hippo.Web.Models;
 using Hippo.Web.Services;
 using Microsoft.AspNetCore.Authorization;
@@ -27,7 +28,7 @@ public class AdminController : SuperController
         _dbContext = dbContext;
         _userService = userService;
         _identityService = identityService;
-        _historyService = historyService; 
+        _historyService = historyService;
         _sshService = sshService;
         _notificationService = notificationService;
     }
@@ -35,7 +36,7 @@ public class AdminController : SuperController
     [HttpGet]
     public async Task<IActionResult> Index()
     {
-        return Ok(await _dbContext.Users.Where(a => a.IsAdmin).AsNoTracking().OrderBy(a => a.FirstName).ThenBy(a => a.LastName).ToListAsync());
+        return Ok(await _dbContext.Accounts.InCluster(Cluster).Where(a => a.IsAdmin).Include(a => a.Owner).AsNoTracking().OrderBy(a => a.Owner.FirstName).ThenBy(a => a.Owner.LastName).ToListAsync());
     }
 
     [HttpPost]
@@ -54,50 +55,77 @@ public class AdminController : SuperController
             return BadRequest("User Not Found");
         }
 
-        var user = await _dbContext.Users.SingleOrDefaultAsync(a => a.Iam == userLookup.Iam);
-        if (user != null)
+        // try to find user account in the cluster
+        var clusterAccount = await _dbContext.Accounts.Include(a => a.Owner).InCluster(Cluster).Where(a => a.Owner.Iam == userLookup.Iam).SingleOrDefaultAsync();
+
+        if (clusterAccount != null)
         {
-            if (user.IsAdmin)
+            // user found with existing account.  upgrade to admin
+            if (clusterAccount.IsAdmin)
             {
                 return BadRequest("User is already an admin.");
             }
-            user.IsAdmin = true;
+            clusterAccount.IsAdmin = true;
         }
         else
         {
-            user = userLookup;
-            user.IsAdmin = true;
-            await _dbContext.Users.AddAsync(user);
+            // need to create new account, but user might already exist
+            var user = await _dbContext.Users.SingleOrDefaultAsync(a => a.Iam == userLookup.Iam);
+
+            if (user == null)
+            {
+                // user doesn't exist, assing them to found user
+                user = userLookup;
+            }
+
+            // now we have the user but need to create the account
+            clusterAccount = new Account
+            {
+                Name = user.Name,
+                CanSponsor = false,
+                Owner = user,
+                IsAdmin = true,
+                IsActive = true,
+                Status = Account.Statuses.PendingApproval,
+                ClusterId = (await _dbContext.Clusters.SingleAsync(c => c.Name == Cluster)).Id
+            };
+
+            _dbContext.Accounts.Add(clusterAccount);
         }
 
-        await _historyService.AddHistory("Admin role added", $"Kerb: {user.Kerberos} IAM: {user.Iam} Email: {user.Email} Name: {user.Name}");
+        await _historyService.AddHistory("Admin role added", $"Kerb: {clusterAccount.Owner.Kerberos} IAM: {clusterAccount.Owner.Iam} Email: {clusterAccount.Owner.Email} Name: {clusterAccount.Owner.Name}");
 
         await _dbContext.SaveChangesAsync();
-        return Ok(user);
-
+        return Ok(clusterAccount);
     }
 
     [HttpPost]
     public async Task<IActionResult> Remove(int id)
     {
-        var user = await _dbContext.Users.SingleOrDefaultAsync(a => a.Id == id);
-        if (user == null)
+        // TODO: change from userID to account ID
+
+        // try to find user account in the cluster
+        var clusterAccount = await _dbContext.Accounts.Include(a => a.Owner).InCluster(Cluster).Where(a => a.Owner.Id == id).SingleOrDefaultAsync();
+
+        if (clusterAccount == null)
         {
             return NotFound();
         }
 
-        if(user.Id == (await _userService.GetCurrentUser()).Id)
+        if (clusterAccount.Owner.Id == (await _userService.GetCurrentUser()).Id)
         {
             return BadRequest("Can't remove yourself");
         }
 
-        user.IsAdmin = false;
+        clusterAccount.IsAdmin = false;
 
-        await _historyService.AddHistory("Admin role removed", $"Kerb: {user.Kerberos} IAM: {user.Iam} Email: {user.Email} Name: {user.Name}");
+        await _historyService.AddHistory("Admin role removed", $"Kerb: {clusterAccount.Owner.Kerberos} IAM: {clusterAccount.Owner.Iam} Email: {clusterAccount.Owner.Email} Name: {clusterAccount.Owner.Name}");
 
         await _dbContext.SaveChangesAsync();
         return Ok();
     }
+
+    // TODO: FROM HERE DOWN the methods need to be updated for the new cluster and account isAdmin feature
 
     [HttpGet]
     public async Task<IActionResult> Sponsors()
@@ -131,9 +159,9 @@ public class AdminController : SuperController
         var isNewAccount = false;
 
         var account = await _dbContext.Accounts.SingleOrDefaultAsync(a => a.OwnerId == user.Id);
-        if(account != null)
+        if (account != null)
         {
-            if(account.Status != Statuses.Active)
+            if (account.Status != Statuses.Active)
             {
                 return BadRequest($"Existing Account for user is not in the Active status: {account.Status}");
             }
@@ -219,7 +247,7 @@ public class AdminController : SuperController
         {
             Log.Error("Error creating Account Decision email");
         }
-        
+
         success = await _notificationService.AdminOverrideDecision(account, true, currentUser); //Notify sponsor
         if (!success)
         {

--- a/Hippo.Web/Controllers/SuperController.cs
+++ b/Hippo.Web/Controllers/SuperController.cs
@@ -5,6 +5,6 @@ namespace Hippo.Web.Controllers
     [AutoValidateAntiforgeryToken]
     public abstract class SuperController : Controller
     {
-        
+        public string? Cluster => ControllerContext.RouteData.Values["cluster"] as string;
     }
 }

--- a/Hippo.Web/Extensions/AuthenticationExtensions.cs
+++ b/Hippo.Web/Extensions/AuthenticationExtensions.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Hippo.Core.Data;
-using Hippo.Core.Domain;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -12,9 +11,8 @@ namespace Hippo.Web.Extensions
 {
     public static class AuthenticationExtensions
     {
-
-
-        public static string GetUserDetails(this HttpContext context) {
+        public static string GetUserDetails(this HttpContext context)
+        {
             var user = context.User.GetUserInfo();
 
             return JsonSerializer.Serialize(user, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });

--- a/Hippo.Web/Extensions/QueryableExtensions.cs
+++ b/Hippo.Web/Extensions/QueryableExtensions.cs
@@ -1,0 +1,19 @@
+using Hippo.Core.Domain;
+
+namespace Hippo.Web.Extensions
+{
+    public static class QueryableExtensions
+    {
+        public static IQueryable<Account> InCluster(this IQueryable<Account> accounts, string? cluster)
+        {
+            // cluster isn't allowed to be null
+            // we could also just use a false condition to return no results
+            if (string.IsNullOrEmpty(cluster))
+            {
+                throw new ArgumentNullException(nameof(cluster));
+            }
+            
+            return accounts.Where(a => a.Cluster.Name == cluster);
+        }
+    }
+}

--- a/Hippo.Web/Handlers/VerifyRoleAccessHandler.cs
+++ b/Hippo.Web/Handlers/VerifyRoleAccessHandler.cs
@@ -29,7 +29,7 @@ namespace Hippo.Web.Handlers
                 return;
             }
 
-            var systemUsers = new[] { "jsylvest", "postit", "cydoval", "sweber" };
+            var systemUsers = new[] { "jsylvest", "postit", "cydoval", "sweber" }; //TODO: Change this to use the user.IsAdmin?
             if (systemUsers.Contains(kerbId))
             {
                 context.Succeed(requirement);
@@ -38,7 +38,12 @@ namespace Hippo.Web.Handlers
 
             if (requirement.RoleStrings.Contains(RoleCodes.AdminRole))
             {
-                if (await _dbContext.Users.AnyAsync(a => a.IsAdmin && a.Iam == userIamId))
+                var clusterName = _httpContext?.HttpContext?.GetRouteValue("cluster") as string;
+                if (string.IsNullOrWhiteSpace(clusterName))
+                {
+                    return;
+                }
+                if (await _dbContext.Accounts.AnyAsync(a => a.Cluster.Name == clusterName && a.IsAdmin && a.Owner.Iam == userIamId))
                 {
                     context.Succeed(requirement);
                     return;

--- a/Hippo.Web/Startup.cs
+++ b/Hippo.Web/Startup.cs
@@ -245,10 +245,10 @@ namespace Hippo.Web
                     constraints: new { controller = "(home|test|system)" }
                 );
 
-                // API routes map to all other controllers
+                // API routes map to all other controllers and require cluster
                 endpoints.MapControllerRoute(
                     name: "API",
-                    pattern: "/api/{controller=Account}/{action=Index}/{id?}");
+                    pattern: "/api/{cluster}/{controller=Account}/{action=Index}/{id?}");
 
                 // any other nonfile route should be handled by the spa, except leave the sockjs route alone if we are in dev mode (hot reloading)
                 if (env.IsDevelopment())

--- a/Hippo.Web/Views/Shared/_Layout.cshtml
+++ b/Hippo.Web/Views/Shared/_Layout.cshtml
@@ -47,6 +47,7 @@
         var Hippo = { user: {}};
 
         Hippo.user.detail = @Html.Raw(await UserService.GetCurrentUserJsonAsync());
+        Hippo.accounts = @Html.Raw(await UserService.GetCurrentAccountsJsonAsync());
         Hippo.antiForgeryToken = "@Xsrf.GetAndStoreTokens(Context).RequestToken";
     </script>
 


### PR DESCRIPTION
Handles structure of multi-cluster support, including all user activity and some example admin activity.

All API endpoints client/server have been updated to take cluster as url param.  Components have been updated to check this param and controllers expose it.  LINQ queries now use custom `InCluster()` filter for most queries.

A few admin functions still need to be updated (see TODO in adminController.cs).  Additionally admin permissions checked by auth policy need to be updated to handle cluster as well.  