### PR TITLE
Approve requests for existing accounts

### DIFF
--- a/Hippo.Web/Controllers/AccountController.cs
+++ b/Hippo.Web/Controllers/AccountController.cs
@@ -4,6 +4,7 @@ using Hippo.Core.Services;
 using Hippo.Web.Extensions;
 using Hippo.Web.Models;
 using Hippo.Web.Services;
+using Hippo.Web.Controllers;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -187,6 +188,13 @@ public class AccountController : SuperController
             await _historyService.AddHistory("Existing account override approve", $"Kerb: {existingAccount.Owner.Kerberos} IAM: {existingAccount.Owner.Iam} Email: {existingAccount.Owner.Email} Name: {existingAccount.Owner.Name}", existingAccount);
 
             await _dbContext.SaveChangesAsync();
+
+            var connectionInfo = await _dbContext.Clusters.GetSshConnectionInfo(Cluster);
+            var tempFileName = $"/var/lib/remote-api/.{existingAccount.Owner.Kerberos}.txt";
+            var fileName = $"/var/lib/remote-api/{existingAccount.Owner.Kerberos}.txt";
+
+            await _sshService.PlaceFile(existingAccount.SshKey, tempFileName, connectionInfo);
+            await _sshService.RenameFile(tempFileName, fileName, connectionInfo);
 
             return Ok(existingAccount);
         }

--- a/Hippo.Web/Controllers/AccountController.cs
+++ b/Hippo.Web/Controllers/AccountController.cs
@@ -146,13 +146,6 @@ public class AccountController : SuperController
         {
             return BadRequest("Please select a sponsor from the list.");
         }
-
-        // make sure current user doesn't already have another account
-        if (await _dbContext.Accounts.InCluster(Cluster).AnyAsync(a => a.Owner.Iam == currentUser.Iam))
-        {
-            return BadRequest("You already have an account");
-        }
-
         if (!(await _dbContext.Accounts.InCluster(Cluster).AnyAsync(a => a.Id == model.SponsorId && a.CanSponsor)))
         {
             return BadRequest("Sponsor not found.");


### PR DESCRIPTION
Automatically approve requests for existing accounts, do not notify the sponsor, and update SSH keys.