### PR TITLE
TEF/EditClusterDescription&Formatting

### DIFF
--- a/Hippo.Web/ClientApp/src/components/Account/Clusters.tsx
+++ b/Hippo.Web/ClientApp/src/components/Account/Clusters.tsx
@@ -26,10 +26,18 @@ export const Clusters = () => {
         <p>
           HiPPO supports multiple clusters. Please select a cluster to view.
         </p>
-        <ul>
+        <ul className="list-clusters">
           {clusters.map((cluster) => (
             <li key={cluster.name}>
-              <NavLink to={`/${cluster.name}`}>{cluster.description}</NavLink>
+              <NavLink 
+                to={`/${cluster.name}`}
+                style={{
+                  fontWeight: "bolder"
+                }}
+              >
+                {`${cluster.name}:`}
+              </NavLink>
+              <p>{cluster.description}</p>
             </li>
           ))}
         </ul>

--- a/Hippo.Web/ClientApp/src/sass/_layout.scss
+++ b/Hippo.Web/ClientApp/src/sass/_layout.scss
@@ -67,6 +67,13 @@ header {
     }
   }
 }
+.list-clusters {
+  li {
+    p {
+      text-indent: 2%;
+    }
+  }
+}
 footer {
   margin-bottom: 3%;
 }


### PR DESCRIPTION
Added colon after cluster name, made cluster name the underlined link not the description, and indented description with a class for uls.