### PR TITLE
fixed an oops in serialized object

### DIFF
--- a/Hippo.Web/Services/YamlService.cs
+++ b/Hippo.Web/Services/YamlService.cs
@@ -40,7 +40,7 @@ namespace Hippo.Web.Services
                         kerb = sponsorAccount.Owner.Kerberos,
                         iam = sponsorAccount.Owner.Iam,
                         mothra = sponsorAccount.Owner.MothraId,
-                        cluster = sponsorAccount.Cluster
+                        cluster = sponsorAccount.Cluster.Name
                     },
                     account = new
                     {


### PR DESCRIPTION
accidentally output the whole cluster obj rather than cluster name in the serialized yaml obj