### PR TITLE
Initial implementation of Hippo.Jobs.PuppetSync

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,35 +1,48 @@
 {
-    "version": "0.2.0",
-    "configurations": [
-        {
-            // Use IntelliSense to find out which attributes exist for C# debugging
-            // Use hover for the description of the existing attributes
-            // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
-            "name": ".NET Core Launch (web)",
-            "type": "coreclr",
-            "request": "launch",
-            "preLaunchTask": "build",
-            // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/Hippo.Web/bin/Debug/net6.0/Hippo.Web.dll",
-            "args": [],
-            "cwd": "${workspaceFolder}/Hippo.Web",
-            "stopAtEntry": false,
-            // Enable launching a web browser when ASP.NET Core starts. For more information: https://aka.ms/VSCode-CS-LaunchJson-WebBrowser
-            "serverReadyAction": {
-                "action": "openExternally",
-                "pattern": "\\bNow listening on:\\s+(https?://\\S+)"
-            },
-            "env": {
-                "ASPNETCORE_ENVIRONMENT": "Development"
-            },
-            "sourceFileMap": {
-                "/Views": "${workspaceFolder}/Views"
-            }
-        },
-        {
-            "name": ".NET Core Attach",
-            "type": "coreclr",
-            "request": "attach"
-        }
-    ]
+  "version": "0.2.0",
+  "configurations": [
+    {
+      // Use IntelliSense to find out which attributes exist for C# debugging
+      // Use hover for the description of the existing attributes
+      // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+      "name": ".NET Core Launch (web)",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      // If you have changed target frameworks, make sure to update the program path.
+      "program": "${workspaceFolder}/Hippo.Web/bin/Debug/net6.0/Hippo.Web.dll",
+      "args": [],
+      "cwd": "${workspaceFolder}/Hippo.Web",
+      "stopAtEntry": false,
+      // Enable launching a web browser when ASP.NET Core starts. For more information: https://aka.ms/VSCode-CS-LaunchJson-WebBrowser
+      "serverReadyAction": {
+        "action": "openExternally",
+        "pattern": "\\bNow listening on:\\s+(https?://\\S+)"
+      },
+      "env": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "sourceFileMap": {
+        "/Views": "${workspaceFolder}/Views"
+      }
+    },
+    {
+      "name": ".NET Core Attach",
+      "type": "coreclr",
+      "request": "attach"
+    },
+    {
+      "name": ".NET Core Launch (puppet sync job)",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "${workspaceFolder}/Hippo.Jobs.PuppetSync/bin/Debug/net6.0/Hippo.Jobs.PuppetSync.dll",
+      "args": [],
+      "cwd": "${workspaceFolder}/Hippo.Jobs.PuppetSync",
+      "stopAtEntry": false,
+      "env": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  ]
 }

--- a/Hippo.Core/Hippo.Core.csproj
+++ b/Hippo.Core/Hippo.Core.csproj
@@ -18,8 +18,10 @@
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.2" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.2" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.9" />
+    <PackageReference Include="Octokit" Version="7.0.0" />
 		<PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
 		<PackageReference Include="SSH.NET" Version="2020.0.1" />
+		<PackageReference Include="YamlDotNet" Version="13.1.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Hippo.Core/Models/PuppetDetails.cs
+++ b/Hippo.Core/Models/PuppetDetails.cs
@@ -1,0 +1,16 @@
+namespace Hippo.Core.Models
+{
+
+
+    public class PuppetDetails
+    {
+        public List<string> Groups { get; set; } = new();
+        public List<PuppetUser> Users { get; set; } = new();
+    }
+
+    public class PuppetUser
+    {
+        public string Kerberos { get; set; }
+        public List<string> Groups { get; set; } = new();
+    }
+}

--- a/Hippo.Core/Models/Settings/PuppetSettings.cs
+++ b/Hippo.Core/Models/Settings/PuppetSettings.cs
@@ -1,0 +1,11 @@
+
+namespace Hippo.Core.Models.Settings
+{
+    public class PuppetSettings
+    {
+        public string RepositoryOwner { get; set; }
+        public string RepositoryName { get; set; }
+        public string RepositoryBranch { get; set; }
+        public string AuthToken { get; set; }
+    }
+}

--- a/Hippo.Core/Services/PuppetService.cs
+++ b/Hippo.Core/Services/PuppetService.cs
@@ -1,0 +1,75 @@
+
+using Hippo.Core.Models;
+using Hippo.Core.Models.Settings;
+using Microsoft.Extensions.Options;
+using Octokit;
+using YamlDotNet.RepresentationModel;
+
+namespace Hippo.Core.Services
+{
+    public interface IPuppetService
+    {
+        Task<PuppetDetails> GetPuppetDetails(string yamlPath);
+    }
+    
+    public class PuppetService : IPuppetService
+    {
+        private readonly PuppetSettings _settings;
+        private readonly GitHubClient _gitHubClient;
+
+        public PuppetService(IOptions<PuppetSettings> settings)
+        {
+            _settings = settings.Value;
+            _gitHubClient = new GitHubClient(new ProductHeaderValue("Hippo"));
+            _gitHubClient.Credentials = new Credentials(_settings.AuthToken);
+        }
+
+
+        public async Task<PuppetDetails> GetPuppetDetails(string yamlPath)
+        {
+            var details = new PuppetDetails();
+
+            // TODO: Octokit doesn't provide a way to get at the file stream, so look into using a plain RestClient.
+            var contents = await _gitHubClient.Repository.Content.GetAllContents(_settings.RepositoryOwner, _settings.RepositoryName, yamlPath);
+            var yaml = contents.First().Content;
+            using var reader = new StringReader(yaml);
+
+            // TODO: YamlStream is a bit of a misnomer. It actually loads entire root node into a DOM. Look into using the lower-level YamlParser.
+            var yamlStream = new YamlStream();
+            yamlStream.Load(reader);
+            var rootNode = (YamlMappingNode)yamlStream.Documents[0].RootNode;
+
+            var groupKey = new YamlScalarNode("group");
+            if (rootNode.Children.ContainsKey(groupKey))
+            {
+                var groupNode = (YamlMappingNode)rootNode.Children[groupKey];
+                foreach (var kvp in groupNode)
+                {
+                    details.Groups.Add(kvp.Key.ToString());
+                }
+            }
+
+            var userKey = new YamlScalarNode("user");
+            if (rootNode.Children.ContainsKey(userKey))
+            {
+                var userGroupsKey = new YamlScalarNode("groups");
+                var users = (YamlMappingNode)rootNode.Children[userKey];
+                foreach (var kvp in users)
+                {
+                    var user = new PuppetUser { Kerberos = kvp.Key.ToString() };
+                    if (kvp.Value is YamlMappingNode userNode && userNode.Children.ContainsKey(userGroupsKey))
+                    {
+                        var groups = (YamlSequenceNode)userNode.Children[userGroupsKey];
+                        foreach (var groupNode in groups)
+                        {
+                            user.Groups.Add(groupNode.ToString());
+                        }
+                    }
+                    details.Users.Add(user);
+                }
+            }
+
+            return details;
+        }
+    }
+}

--- a/Hippo.Jobs.Core/Hippo.Jobs.Core.csproj
+++ b/Hippo.Jobs.Core/Hippo.Jobs.Core.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+    <UserSecretsId>c14737e0-e801-4dfa-bc8d-ce9130c807c6</UserSecretsId>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+		<WarningLevel>5</WarningLevel>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Elastic.Apm.NetCoreAll" Version="1.12.1"/>
+		<PackageReference Include="Elastic.Apm.SerilogEnricher" Version="1.5.3"/>
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0"/>
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0"/>
+		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.0"/>
+		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.0"/>
+		<PackageReference Include="Serilog" Version="2.10.0"/>
+		<PackageReference Include="Serilog.AspNetCore" Version="4.1.0"/>
+		<PackageReference Include="Serilog.Exceptions" Version="8.0.0"/>
+		<PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0"/>
+		<PackageReference Include="Serilog.Sinks.Console" Version="4.0.1"/>
+		<PackageReference Include="Serilog.Sinks.Elasticsearch" Version="8.4.1"/>
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Hippo.Core\Hippo.Core.csproj"/>
+	</ItemGroup>
+</Project>

--- a/Hippo.Jobs.Core/JobBase.cs
+++ b/Hippo.Jobs.Core/JobBase.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+
+namespace Hippo.Jobs.Core
+{
+    public abstract class JobBase
+    {
+        public static IConfigurationRoot Configuration { get; set; } = null!;
+
+        protected static void Configure()
+        {
+            var builder = new ConfigurationBuilder()
+                .SetBasePath(Directory.GetCurrentDirectory())
+                .AddJsonFile("appsettings.json");
+
+            var environmentName = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+
+            if (string.Equals(environmentName, "development", StringComparison.OrdinalIgnoreCase))
+            {
+                builder.AddUserSecrets<JobBase>();
+            }
+
+            builder.AddEnvironmentVariables();
+            Configuration = builder.Build();
+
+            LogConfiguration.Setup(Configuration); 
+        }
+    }
+}

--- a/Hippo.Jobs.Core/LogConfiguration.cs
+++ b/Hippo.Jobs.Core/LogConfiguration.cs
@@ -88,14 +88,6 @@ namespace Hippo.Jobs.Core
             }
 
             throw new Exception("Couldn't get log configured");
-
-            //return logConfig.WriteTo.Elasticsearch(new ElasticsearchSinkOptions(new Uri(esUrl))
-            //{
-            //    //AutoRegisterTemplate = true,
-            //    //AutoRegisterTemplateVersion = AutoRegisterTemplateVersion.ESv7
-            //    IndexFormat = "aspnet-Hippo-{0:yyyy.MM.dd}",
-            //    TypeName = null
-            //});
         }
     }
 }

--- a/Hippo.Jobs.Core/LogConfiguration.cs
+++ b/Hippo.Jobs.Core/LogConfiguration.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using Serilog;
+using Serilog.Events;
+using Serilog.Exceptions;
+using Serilog.Sinks.Elasticsearch;
+
+namespace Hippo.Jobs.Core
+{
+    public static class LogConfiguration
+    {
+        private static bool _loggingSetup;
+
+        private static IConfigurationRoot _configuration = null!;
+
+        public static void Setup(IConfigurationRoot configuration)
+        {
+            if (_loggingSetup) return;
+
+            // save configuration for later calls
+            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+
+            // create global logger with standard configuration
+            Log.Logger = GetConfiguration().CreateLogger();
+
+            AppDomain.CurrentDomain.UnhandledException += (sender, e) => Log.Fatal(e.ExceptionObject as Exception, e.ExceptionObject.ToString());
+
+            AppDomain.CurrentDomain.ProcessExit += (sender, e) => Log.CloseAndFlush();
+
+#if DEBUG
+            Serilog.Debugging.SelfLog.Enable(msg => Debug.WriteLine(msg));
+#endif
+
+            _loggingSetup = true;
+        }
+
+        /// <summary>
+        /// Get a logger configuration that logs to stackify
+        /// </summary>
+        /// <returns></returns>
+        public static LoggerConfiguration GetConfiguration()
+        {
+            if (_configuration == null) throw new InvalidOperationException("Call Setup() before requesting a Logger Configuration"); ;
+
+            // standard logger
+            var logConfig = new LoggerConfiguration()
+                .MinimumLevel.Debug()
+                .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
+                // .MinimumLevel.Override("Microsoft.EntityFrameworkCore", LogEventLevel.Warning) // uncomment this to hide EF core general info logs
+                .MinimumLevel.Override("System", LogEventLevel.Warning)
+                .Enrich.FromLogContext()
+                .Enrich.WithExceptionDetails();
+
+            // various sinks
+            logConfig = logConfig
+                .WriteTo.Console()
+                .WriteToElasticSearchCustom();
+
+            return logConfig;
+        }
+
+        private static LoggerConfiguration WriteToElasticSearchCustom(this LoggerConfiguration logConfig)
+        {
+            // get logging config for ES endpoint (re-use some stackify settings for now)
+            var loggingSection = _configuration.GetSection("Serilog");
+
+            var esUrl = loggingSection.GetValue<string>("ElasticUrl"); //logging
+
+            // only continue if a valid http url is setup in the config
+            if (esUrl == null || !esUrl.StartsWith("http"))
+            {
+                return logConfig;
+            }
+
+            logConfig.Enrich.WithProperty("Application", loggingSection.GetValue<string>("AppName"));
+            logConfig.Enrich.WithProperty("AppEnvironment", loggingSection.GetValue<string>("Environment"));
+
+            if (Uri.TryCreate(esUrl, UriKind.Absolute, out var elasticUri))
+            {
+                return logConfig.WriteTo.Elasticsearch(new ElasticsearchSinkOptions(elasticUri)
+                {
+                    IndexFormat = "aspnet-Hippo-{0:yyyy.MM}",
+                    TypeName = null
+                });
+            }
+
+            throw new Exception("Couldn't get log configured");
+
+            //return logConfig.WriteTo.Elasticsearch(new ElasticsearchSinkOptions(new Uri(esUrl))
+            //{
+            //    //AutoRegisterTemplate = true,
+            //    //AutoRegisterTemplateVersion = AutoRegisterTemplateVersion.ESv7
+            //    IndexFormat = "aspnet-Hippo-{0:yyyy.MM.dd}",
+            //    TypeName = null
+            //});
+        }
+    }
+}

--- a/Hippo.Jobs.Core/Properties/launchSettings.json
+++ b/Hippo.Jobs.Core/Properties/launchSettings.json
@@ -1,0 +1,11 @@
+{
+  "profiles": {
+    "Hippo.Jobs.Core": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "Key": "Value",
+        "ASPNETCORE_ENVIRONMENT": "development"
+      }
+    }
+  }
+}

--- a/Hippo.Jobs.PuppetSync/Hippo.Jobs.PuppetSync.csproj
+++ b/Hippo.Jobs.PuppetSync/Hippo.Jobs.PuppetSync.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.2" />
+  </ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Hippo.Core\Hippo.Core.csproj"/>
+		<ProjectReference Include="..\Hippo.Jobs.Core\Hippo.Jobs.Core.csproj"/>
+	</ItemGroup>
+  
+  <ItemGroup>
+		<None Update="appsettings.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="settings.job">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="run.cmd">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
+</Project>

--- a/Hippo.Jobs.PuppetSync/Program.cs
+++ b/Hippo.Jobs.PuppetSync/Program.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Threading.Tasks;
+using Hippo.Core.Data;
+using Hippo.Core.Models.Settings;
+using Hippo.Core.Services;
+using Hippo.Core.Utilities;
+using Hippo.Jobs.Core;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Serilog;
+
+namespace Hippo.Jobs.PuppetSync
+{
+    class Program : JobBase
+    {
+        private static ILogger _log = null!;
+
+        static void Main(string[] args)
+        {
+            Configure();
+            var assembyName = typeof(Program).Assembly.GetName();
+            _log = Log.Logger
+                .ForContext("jobname", assembyName.Name)
+                .ForContext("jobid", Guid.NewGuid());
+
+            _log.Information("Running {job} build {build}", assembyName.Name, assembyName.Version);
+
+            // setup di
+            var provider = ConfigureServices();
+
+            var puppetService = provider.GetRequiredService<IPuppetService>();
+
+            SyncPuppetAccounts(puppetService).GetAwaiter().GetResult();
+        }
+
+
+        private static ServiceProvider ConfigureServices()
+        {
+            IServiceCollection services = new ServiceCollection();
+            services.AddOptions();
+
+            var efProvider = Configuration.GetValue("Provider", "none");
+            if (efProvider == "SqlServer" || (efProvider == "none" && Configuration.GetValue<bool>("Dev:UseSql")))
+            {
+                services.AddDbContextPool<AppDbContext, AppDbContextSqlServer>((serviceProvider, o) =>
+                {
+                    o.UseSqlServer(Configuration.GetConnectionString("DefaultConnection"),
+                        sqlOptions =>
+                        {
+                            sqlOptions.MigrationsAssembly("Hippo.Core");
+                        });
+#if DEBUG
+                    o.EnableSensitiveDataLogging();
+#endif
+                });
+            }
+            else
+            {
+                services.AddDbContextPool<AppDbContext, AppDbContextSqlite>((serviceProvider, o) =>
+                {
+                    var connection = new SqliteConnection("Data Source=hippo.db");
+                    o.UseSqlite(connection, sqliteOptions =>
+                    {
+                        sqliteOptions.MigrationsAssembly("Hippo.Core");
+                    });
+
+#if DEBUG
+                    o.EnableSensitiveDataLogging();
+#endif
+                });
+            }
+
+            services.Configure<PuppetSettings>(Configuration.GetSection("Puppet"));
+            services.AddSingleton<IPuppetService, PuppetService>();
+
+
+            return services.BuildServiceProvider();
+        }
+
+        private static async Task SyncPuppetAccounts(IPuppetService puppetService)
+        {
+            _log.Information("Syncing Puppet accounts");
+
+            var accounts = await puppetService.GetPuppetDetails("tbd...");
+
+            _log.Information("Found {count} users", accounts.Users.Count);
+        }
+    }
+}

--- a/Hippo.Jobs.PuppetSync/appsettings.json
+++ b/Hippo.Jobs.PuppetSync/appsettings.json
@@ -7,7 +7,7 @@
     }
   },
   "Serilog": {
-    "AppName": "Hippo",
+    "AppName": "Hippo.Jobs.PuppetSync",
     "Environment": "[External]",
     "ElasticUrl": "[External]"
   },

--- a/Hippo.Jobs.PuppetSync/appsettings.json
+++ b/Hippo.Jobs.PuppetSync/appsettings.json
@@ -1,0 +1,30 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "Serilog": {
+    "AppName": "Hippo",
+    "Environment": "[External]",
+    "ElasticUrl": "[External]"
+  },
+  "ElasticApm": {
+    "Enabled": false,
+    "SecretToken": "[External]",
+    "ServerUrls": "[External]",
+    "ServiceName": "Hippo",
+    "Environment": "Development"
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "[External]"
+  },
+  "Puppet": {
+    "RepositoryOwner": "ucdavis",
+    "RepositoryName": "[external]",
+    "ReposotoryBranch": "main",
+    "AuthToken": "[external]"
+  }
+}

--- a/Hippo.Jobs.PuppetSync/run.cmd
+++ b/Hippo.Jobs.PuppetSync/run.cmd
@@ -1,0 +1,3 @@
+@echo off
+
+dotnet Hippo.Jobs.PuppetSync.dll

--- a/Hippo.Jobs.PuppetSync/settings.job
+++ b/Hippo.Jobs.PuppetSync/settings.job
@@ -1,0 +1,3 @@
+{
+  "schedule": "0 0 13 * * Mon-Fri"
+}

--- a/Hippo.Web/Hippo.Web.csproj
+++ b/Hippo.Web/Hippo.Web.csproj
@@ -26,7 +26,6 @@
     <PackageReference Include="Serilog.Enrichers.ClientInfo" Version="1.1.4" />
     <PackageReference Include="Serilog.Exceptions" Version="8.0.0" />
     <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="8.4.1" />
-    <PackageReference Include="YamlDotNet" Version="13.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Hippo.Web/appsettings.json
+++ b/Hippo.Web/appsettings.json
@@ -48,5 +48,11 @@
     "RecreateDb": "false",
     "InitializeDb": "false",
     "UseSql": "true"
+  },
+  "Puppet": {
+    "RepositoryOwner": "ucdavis",
+    "RepositoryName": "[external]",
+    "ReposotoryBranch": "main",
+    "AuthToken": "[external]"
   }
 }

--- a/azure-pipelines-web.yml
+++ b/azure-pipelines-web.yml
@@ -89,6 +89,14 @@ stages:
         projects: './Hippo.Web/Hippo.Web.csproj'
         arguments: '--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)/'
 
+    - task: DotNetCoreCLI@2
+      displayName: 'Publish Hippo Jobs: PuppetSync'
+      inputs:
+        command: 'publish'
+        publishWebProjects: false
+        zipAfterPublish: false
+        projects: './Hippo.Jobs.PuppetSync/Hippo.Jobs.PuppetSync.csproj'
+        arguments: '--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)/app_data/jobs/triggered'
 
     - task: PublishBuildArtifacts@1
       condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')

--- a/hippo.sln
+++ b/hippo.sln
@@ -20,6 +20,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hippo.Email", "Hippo.Email\Hippo.Email.csproj", "{C8297C36-9223-4E04-A8FD-9D2E3EFA0AC2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hippo.Jobs.Core", "Hippo.Jobs.Core\Hippo.Jobs.Core.csproj", "{A209A012-28D5-4022-AFEF-8BC7415234C0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hippo.Jobs.PuppetSync", "Hippo.Jobs.PuppetSync\Hippo.Jobs.PuppetSync.csproj", "{8CC5F984-8298-4592-A1D9-CDA147A2D7C3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -42,6 +46,14 @@ Global
 		{C8297C36-9223-4E04-A8FD-9D2E3EFA0AC2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C8297C36-9223-4E04-A8FD-9D2E3EFA0AC2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C8297C36-9223-4E04-A8FD-9D2E3EFA0AC2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A209A012-28D5-4022-AFEF-8BC7415234C0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A209A012-28D5-4022-AFEF-8BC7415234C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A209A012-28D5-4022-AFEF-8BC7415234C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A209A012-28D5-4022-AFEF-8BC7415234C0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8CC5F984-8298-4592-A1D9-CDA147A2D7C3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8CC5F984-8298-4592-A1D9-CDA147A2D7C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8CC5F984-8298-4592-A1D9-CDA147A2D7C3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8CC5F984-8298-4592-A1D9-CDA147A2D7C3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Doesn't actually do anything right now. Though it will pull data if you tweak `var accounts = await puppetService.GetPuppetDetails("tbd...");` to actually point to a yaml file in the accounts repo. I didn't want to hard-code that. I'm thinking the yaml file paths should probably be stored in the `dbo.Clusters` table, but wanted to get an alternative App Service running, along with its own db so that deployments from merges to `main` and `dev` don't have migrations clobbering each other. So this should automatically deploy to https://hippo-dev-test.azurewebsites.net