### PR TITLE
filter by name

### DIFF
--- a/Hippo.Web/ClientApp/src/components/Admin/Groups.tsx
+++ b/Hippo.Web/ClientApp/src/components/Admin/Groups.tsx
@@ -117,8 +117,9 @@ export const Groups = () => {
     () => [
       {
         Header: "Group",
-        accessor: (group) => (
-          <GroupNameWithTooltip group={group} showDisplayName={false} />
+        accessor: 'name',
+        Cell: (props) => (
+          <GroupNameWithTooltip group={props.row.original} showDisplayName={false} />
         ),
       },
       {


### PR DESCRIPTION
switch accessor to simple name and use Cell for custom rendering.  this way filtering still works on string name value.  Closes #247
