### PR TITLE
Make all group columns sortable and filterable

### DIFF
--- a/Hippo.Web/ClientApp/src/components/Account/ActiveAccounts.tsx
+++ b/Hippo.Web/ClientApp/src/components/Account/ActiveAccounts.tsx
@@ -5,6 +5,7 @@ import { authenticatedFetch } from "../../util/api";
 import { ReactTable } from "../../Shared/ReactTable";
 import { Column } from "react-table";
 import { GroupNameWithTooltip } from "../Group/GroupNameWithTooltip";
+import { getGroupModelString } from "../../util/StringHelpers";
 
 export const ActiveAccounts = () => {
   const [accounts, setAccounts] = useState<AccountModel[]>();
@@ -15,14 +16,15 @@ export const ActiveAccounts = () => {
     () => [
       {
         Header: "Groups",
-        accessor: (row) => (
+        accessor: (row) => getGroupModelString(row.groups),
+        Cell: (props) => (
           <>
-            {row.groups.map((g, i) => (
+            {props.row.original.groups.map((g, i) => (
               <>
                 {i > 0 && ", "}
                 <GroupNameWithTooltip
                   group={g}
-                  id={row.id.toString()}
+                  id={props.row.original.id.toString()}
                   key={i}
                 />
               </>

--- a/Hippo.Web/ClientApp/src/components/Account/ActiveAccounts.tsx
+++ b/Hippo.Web/ClientApp/src/components/Account/ActiveAccounts.tsx
@@ -75,6 +75,7 @@ export const ActiveAccounts = () => {
         .map((a) => a.groups)
         .flat()
         .filter((g) => g !== null)
+        .map((g) => g.name)
     ).size;
     return (
       <div className="row justify-content-center">

--- a/Hippo.Web/ClientApp/src/components/Account/Requests.tsx
+++ b/Hippo.Web/ClientApp/src/components/Account/Requests.tsx
@@ -6,7 +6,7 @@ import { usePromiseNotification } from "../../util/Notifications";
 import { useParams } from "react-router-dom";
 import { ReactTable } from "../../Shared/ReactTable";
 import { Column } from "react-table";
-import { SplitCamelCase } from "../../util/StringHelpers";
+import { SplitCamelCase, getGroupModelString } from "../../util/StringHelpers";
 import { GroupNameWithTooltip } from "../Group/GroupNameWithTooltip";
 
 export const Requests = () => {
@@ -88,10 +88,11 @@ export const Requests = () => {
       },
       {
         Header: "Group",
-        accessor: (request) => (
+        accessor: (row) => getGroupModelString(row.groupModel),
+        Cell: (props) => (
           <GroupNameWithTooltip
-            group={request.groupModel}
-            id={request.id.toString()}
+            group={props.row.original.groupModel}
+            showDisplayName={false}
           />
         ),
         sortable: true,

--- a/Hippo.Web/ClientApp/src/components/Admin/GroupAdmins.tsx
+++ b/Hippo.Web/ClientApp/src/components/Admin/GroupAdmins.tsx
@@ -5,6 +5,7 @@ import { authenticatedFetch } from "../../util/api";
 import { ReactTable } from "../../Shared/ReactTable";
 import { Column } from "react-table";
 import { GroupNameWithTooltip } from "../Group/GroupNameWithTooltip";
+import { getGroupModelString } from "../../util/StringHelpers";
 
 export const GroupAdmins = () => {
   // get all accounts that need approval and list them
@@ -32,8 +33,12 @@ export const GroupAdmins = () => {
     () => [
       {
         Header: "Group",
-        accessor: (ga, i) => (
-          <GroupNameWithTooltip group={ga.group} id={i.toString()} />
+        accessor: (row) => getGroupModelString(row.group),
+        Cell: (props) => (
+          <GroupNameWithTooltip
+            group={props.row.original.group}
+            showDisplayName={false}
+          />
         ),
         sortable: true,
       },

--- a/Hippo.Web/ClientApp/src/components/Admin/Groups.tsx
+++ b/Hippo.Web/ClientApp/src/components/Admin/Groups.tsx
@@ -7,6 +7,7 @@ import { usePromiseNotification } from "../../util/Notifications";
 import { ReactTable } from "../../Shared/ReactTable";
 import { Column } from "react-table";
 import { GroupNameWithTooltip } from "../Group/GroupNameWithTooltip";
+import { getGroupModelString } from "../../util/StringHelpers";
 
 export const Groups = () => {
   // get all accounts that need approval and list them
@@ -117,9 +118,12 @@ export const Groups = () => {
     () => [
       {
         Header: "Group",
-        accessor: 'name',
+        accessor: (row) => getGroupModelString(row),
         Cell: (props) => (
-          <GroupNameWithTooltip group={props.row.original} showDisplayName={false} />
+          <GroupNameWithTooltip
+            group={props.row.original}
+            showDisplayName={false}
+          />
         ),
       },
       {

--- a/Hippo.Web/ClientApp/src/util/StringHelpers.ts
+++ b/Hippo.Web/ClientApp/src/util/StringHelpers.ts
@@ -1,3 +1,5 @@
+import { GroupModel } from "../types";
+
 export const SplitCamelCase = (str: string) => {
   return (
     str
@@ -6,4 +8,18 @@ export const SplitCamelCase = (str: string) => {
       // uppercase the first character
       .replace(/^./, (str) => str.toUpperCase())
   );
+};
+
+export const getGroupModelString = (arg: GroupModel | GroupModel[]) => {
+  const groups = Array.isArray(arg) ? arg : [arg];
+  var values = [
+    // start with names of groups for sortability
+    ...groups.map((g) => g.name),
+    // then include remaining properties for filtering
+    ...groups.map((g) => [
+      g.displayName,
+      g.admins.map((a) => [a.name, a.email, a.kerberos]),
+    ]),
+  ];
+  return values.flat().join(" ");
 };


### PR DESCRIPTION
I applied the accessor/Cell fix to the three remaining table columns that contain the `<GroupNameWithTooltip />` component. Also updated the accessors to include more details from `GroupModel` for better filtering.

Closes #247 