### PR TITLE
Replace personal access token with github app authentication 

### DIFF
--- a/Hippo.Core/Extensions/StringExtensions.cs
+++ b/Hippo.Core/Extensions/StringExtensions.cs
@@ -33,4 +33,16 @@ public static class StringExtensions
         // check if key header matches
         return m.Groups["key"].Value.StartsWith(keyHeaderBase64);
     }
+
+    public static string EncodeBase64(this string value)
+    {
+        var valueBytes = Encoding.UTF8.GetBytes(value);
+        return Convert.ToBase64String(valueBytes);
+    }
+
+    public static string DecodeBase64(this string value)
+    {
+        var valueBytes = Convert.FromBase64String(value);
+        return Encoding.UTF8.GetString(valueBytes);
+    }
 }

--- a/Hippo.Core/Hippo.Core.csproj
+++ b/Hippo.Core/Hippo.Core.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Mjml.Net" Version="3.3.0" />
     <PackageReference Include="Octokit" Version="7.0.0" />
 		<PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
-		<PackageReference Include="SSH.NET" Version="2020.0.1" />
+		<PackageReference Include="SSH.NET" Version="2023.0.0" />
 		<PackageReference Include="YamlDotNet" Version="13.1.1" />
 	</ItemGroup>
 

--- a/Hippo.Core/Models/Settings/PuppetSettings.cs
+++ b/Hippo.Core/Models/Settings/PuppetSettings.cs
@@ -6,6 +6,8 @@ namespace Hippo.Core.Models.Settings
         public string RepositoryOwner { get; set; }
         public string RepositoryName { get; set; }
         public string RepositoryBranch { get; set; } = "main";
-        public string AuthToken { get; set; }
+        public string GithubAppKey { get; set; }
+        public string GithubAppId { get; set; }
+        public long GithubAppInstallationId { get; set; }
     }
 }

--- a/Hippo.Core/Services/PuppetService.cs
+++ b/Hippo.Core/Services/PuppetService.cs
@@ -29,6 +29,7 @@ namespace Hippo.Core.Services
 
         private async Task<GitHubClient> GetGithubClient()
         {
+            // caching token for 10 minutes, which is the limit for GitHub API's
             if (!_memoryCache.TryGetValue("github-app-installation-token", out string appInstallationToken))
             {
                 // create an app token to authenticate our request for an app installation token

--- a/Hippo.Jobs.PuppetSync/Program.cs
+++ b/Hippo.Jobs.PuppetSync/Program.cs
@@ -69,7 +69,7 @@ namespace Hippo.Jobs.PuppetSync
 #endif
                 });
             }
-
+            services.AddMemoryCache();
             services.Configure<PuppetSettings>(Configuration.GetSection("Puppet"));
             services.Configure<AuthSettings>(Configuration.GetSection("Authentication"));
             services.AddSingleton<IPuppetService, PuppetService>();

--- a/Hippo.Jobs.PuppetSync/appsettings.json
+++ b/Hippo.Jobs.PuppetSync/appsettings.json
@@ -25,6 +25,8 @@
     "RepositoryOwner": "ucdavis",
     "RepositoryName": "[external]",
     "ReposotoryBranch": "main",
-    "AuthToken": "[external]"
+    "GithubAppKey": "[external]",
+    "GithubAppId": "[external]",
+    "GithubAppInstallationId": "[external]"
   }
 }

--- a/Hippo.Web/appsettings.json
+++ b/Hippo.Web/appsettings.json
@@ -52,7 +52,9 @@
   "Puppet": {
     "RepositoryOwner": "ucdavis",
     "RepositoryName": "[external]",
-    "RepositoryBranch": "main",
-    "AuthToken": "[external]"
+    "ReposotoryBranch": "main",
+    "GithubAppKey": "[external]",
+    "GithubAppId": "[external]",
+    "GithubAppInstallationId": "[external]"
   }
 }


### PR DESCRIPTION
I couldn't use Octokit's suggestion to use the GitHubJwt nuget package for generating the jwt, because BouncyCastle would fail to read the pem key no matter how I formatted it. And just about all the examples out there are based on BouncyCastle. But it turns out to be not too complex just using `System.Security.Cryptography` directly.

I've updated secrets in 1pass.
