### PR TITLE
Don't call Include() on a string property

### DIFF
--- a/Hippo.Web/Controllers/RequestController.cs
+++ b/Hippo.Web/Controllers/RequestController.cs
@@ -82,7 +82,6 @@ public class RequestController : SuperController
             .CanAccess(_dbContext, Cluster, currentUser.Iam, isClusterOrSystemAdmin)
             .Include(r => r.Requester)
             .Include(r => r.Cluster)
-            .Include(r => r.Group)
             .SingleOrDefaultAsync();
 
         if (request == null)


### PR DESCRIPTION
Quick fix. It will need to deploy to prod soon. Tested approve process on hippo-test.

This was caused by a refactor to eliminate foreign keys to Groups and Accounts so that they could be easily deleted. Navigation properties were changed to just strings. I'm surprised the Include extension method doesn't restrict the property type to at least be a class.