### PR TITLE
Sync and display puppet resource data

### DIFF
--- a/Hippo.Core/Domain/Account.cs
+++ b/Hippo.Core/Domain/Account.cs
@@ -39,6 +39,8 @@ namespace Hippo.Core.Domain
 
         public string SshKey { get; set; }
 
+        public string Data { get; set; }
+
         public int? OwnerId { get; set; }
         public User Owner { get; set; }
 

--- a/Hippo.Core/Domain/Group.cs
+++ b/Hippo.Core/Domain/Group.cs
@@ -20,6 +20,8 @@ namespace Hippo.Core.Domain
         public int ClusterId { get; set; }
         public Cluster Cluster { get; set; }
 
+        public string Data { get; set; } = "";
+
         [JsonIgnore]
         public List<Account> MemberAccounts { get; set; } = new();
 

--- a/Hippo.Core/Migrations/SqlServer/20240409233559_PuppetResourceData.Designer.cs
+++ b/Hippo.Core/Migrations/SqlServer/20240409233559_PuppetResourceData.Designer.cs
@@ -3,27 +3,34 @@ using System;
 using Hippo.Core.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace Hippo.Core.Migrations.Sqlite
+namespace Hippo.Core.Migrations.SqlServer
 {
-    [DbContext(typeof(AppDbContextSqlite))]
-    partial class AppDbContextSqliteModelSnapshot : ModelSnapshot
+    [DbContext(typeof(AppDbContextSqlServer))]
+    [Migration("20240409233559_PuppetResourceData")]
+    partial class PuppetResourceData
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder.HasAnnotation("ProductVersion", "6.0.19");
+            modelBuilder
+                .HasAnnotation("ProductVersion", "6.0.19")
+                .HasAnnotation("Relational:MaxIdentifierLength", 128);
+
+            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder, 1L, 1);
 
             modelBuilder.Entity("AccessTypeAccount", b =>
                 {
                     b.Property<int>("AccessTypesId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("AccountsId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.HasKey("AccessTypesId", "AccountsId");
 
@@ -35,10 +42,10 @@ namespace Hippo.Core.Migrations.Sqlite
             modelBuilder.Entity("AccessTypeCluster", b =>
                 {
                     b.Property<int>("AccessTypesId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("ClustersId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.HasKey("AccessTypesId", "ClustersId");
 
@@ -51,12 +58,14 @@ namespace Hippo.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"), 1L, 1);
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.HasKey("Id");
 
@@ -70,37 +79,39 @@ namespace Hippo.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"), 1L, 1);
 
                     b.Property<int>("ClusterId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Data")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Email")
                         .HasMaxLength(300)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(300)");
 
                     b.Property<string>("Kerberos")
                         .HasMaxLength(20)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(20)");
 
                     b.Property<string>("Name")
                         .HasMaxLength(100)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(100)");
 
                     b.Property<int?>("OwnerId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("SshKey")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<DateTime>("UpdatedOn")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.HasKey("Id");
 
@@ -125,42 +136,44 @@ namespace Hippo.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"), 1L, 1);
 
                     b.Property<string>("Description")
                         .IsRequired()
                         .HasMaxLength(250)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(250)");
 
                     b.Property<string>("Domain")
                         .HasMaxLength(250)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(250)");
 
                     b.Property<string>("Email")
                         .HasMaxLength(250)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(250)");
 
                     b.Property<bool>("IsActive")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasDefaultValue(true);
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(20)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(20)");
 
                     b.Property<string>("SshKeyId")
                         .HasMaxLength(40)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<string>("SshName")
                         .HasMaxLength(250)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(250)");
 
                     b.Property<string>("SshUrl")
                         .HasMaxLength(250)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(250)");
 
                     b.HasKey("Id");
 
@@ -173,22 +186,24 @@ namespace Hippo.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"), 1L, 1);
 
                     b.Property<int>("ClusterId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("Data")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("DisplayName")
                         .HasMaxLength(250)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(250)");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(32)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(32)");
 
                     b.HasKey("Id");
 
@@ -201,10 +216,10 @@ namespace Hippo.Core.Migrations.Sqlite
             modelBuilder.Entity("Hippo.Core.Domain.GroupAdminAccount", b =>
                 {
                     b.Property<int>("AccountId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("GroupId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.HasKey("AccountId", "GroupId");
 
@@ -216,10 +231,10 @@ namespace Hippo.Core.Migrations.Sqlite
             modelBuilder.Entity("Hippo.Core.Domain.GroupMemberAccount", b =>
                 {
                     b.Property<int>("AccountId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("GroupId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.HasKey("AccountId", "GroupId");
 
@@ -232,30 +247,32 @@ namespace Hippo.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"), 1L, 1);
 
                     b.Property<int?>("ActedById")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime>("ActedDate")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Action")
                         .HasMaxLength(100)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(100)");
 
                     b.Property<bool>("AdminAction")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bit");
 
                     b.Property<int>("ClusterId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("Details")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Status")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.HasKey("Id");
 
@@ -274,16 +291,18 @@ namespace Hippo.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"), 1L, 1);
 
                     b.Property<int?>("ClusterId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("RoleId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("UserId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.HasKey("Id");
 
@@ -300,30 +319,32 @@ namespace Hippo.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"), 1L, 1);
 
                     b.Property<string>("Action")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Data")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("ErrorMessage")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int?>("RequestId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("Status")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<DateTime>("UpdatedAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.HasKey("Id");
 
@@ -344,46 +365,48 @@ namespace Hippo.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"), 1L, 1);
 
                     b.Property<string>("Action")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<int?>("ActorId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int>("ClusterId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Data")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Group")
                         .HasMaxLength(32)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(32)");
 
                     b.Property<int>("RequesterId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<string>("SshKey")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Status")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<string>("SupervisingPI")
                         .HasMaxLength(100)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(100)");
 
                     b.Property<DateTime>("UpdatedOn")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.HasKey("Id");
 
@@ -406,12 +429,14 @@ namespace Hippo.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"), 1L, 1);
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.HasKey("Id");
 
@@ -424,7 +449,7 @@ namespace Hippo.Core.Migrations.Sqlite
             modelBuilder.Entity("Hippo.Core.Domain.TempGroup", b =>
                 {
                     b.Property<string>("Group")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(450)");
 
                     b.HasKey("Group");
 
@@ -434,7 +459,7 @@ namespace Hippo.Core.Migrations.Sqlite
             modelBuilder.Entity("Hippo.Core.Domain.TempKerberos", b =>
                 {
                     b.Property<string>("Kerberos")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(450)");
 
                     b.HasKey("Kerberos");
 
@@ -445,41 +470,44 @@ namespace Hippo.Core.Migrations.Sqlite
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"), 1L, 1);
 
                     b.Property<string>("Email")
                         .IsRequired()
                         .HasMaxLength(300)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(300)");
 
                     b.Property<string>("FirstName")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<string>("Iam")
                         .HasMaxLength(10)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(10)");
 
                     b.Property<string>("Kerberos")
                         .HasMaxLength(20)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(20)");
 
                     b.Property<string>("LastName")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<string>("MothraId")
                         .HasMaxLength(20)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("nvarchar(20)");
 
                     b.HasKey("Id");
 
                     b.HasIndex("Email");
 
                     b.HasIndex("Iam")
-                        .IsUnique();
+                        .IsUnique()
+                        .HasFilter("[Iam] IS NOT NULL");
 
                     b.ToTable("Users");
                 });

--- a/Hippo.Core/Migrations/SqlServer/20240409233559_PuppetResourceData.cs
+++ b/Hippo.Core/Migrations/SqlServer/20240409233559_PuppetResourceData.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Hippo.Core.Migrations.SqlServer
+{
+    public partial class PuppetResourceData : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Data",
+                table: "Groups",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Data",
+                table: "Accounts",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Data",
+                table: "Groups");
+
+            migrationBuilder.DropColumn(
+                name: "Data",
+                table: "Accounts");
+        }
+    }
+}

--- a/Hippo.Core/Migrations/SqlServer/AppDbContextSqlServerModelSnapshot.cs
+++ b/Hippo.Core/Migrations/SqlServer/AppDbContextSqlServerModelSnapshot.cs
@@ -87,6 +87,9 @@ namespace Hippo.Core.Migrations.SqlServer
                     b.Property<DateTime>("CreatedOn")
                         .HasColumnType("datetime2");
 
+                    b.Property<string>("Data")
+                        .HasColumnType("nvarchar(max)");
+
                     b.Property<string>("Email")
                         .HasMaxLength(300)
                         .HasColumnType("nvarchar(300)");
@@ -187,6 +190,9 @@ namespace Hippo.Core.Migrations.SqlServer
 
                     b.Property<int>("ClusterId")
                         .HasColumnType("int");
+
+                    b.Property<string>("Data")
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("DisplayName")
                         .HasMaxLength(250)

--- a/Hippo.Core/Migrations/Sqlite/20240409233551_PuppetResourceData.Designer.cs
+++ b/Hippo.Core/Migrations/Sqlite/20240409233551_PuppetResourceData.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Hippo.Core.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Hippo.Core.Migrations.Sqlite
 {
     [DbContext(typeof(AppDbContextSqlite))]
-    partial class AppDbContextSqliteModelSnapshot : ModelSnapshot
+    [Migration("20240409233551_PuppetResourceData")]
+    partial class PuppetResourceData
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "6.0.19");

--- a/Hippo.Core/Migrations/Sqlite/20240409233551_PuppetResourceData.cs
+++ b/Hippo.Core/Migrations/Sqlite/20240409233551_PuppetResourceData.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Hippo.Core.Migrations.Sqlite
+{
+    public partial class PuppetResourceData : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Data",
+                table: "Groups",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Data",
+                table: "Accounts",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Data",
+                table: "Groups");
+
+            migrationBuilder.DropColumn(
+                name: "Data",
+                table: "Accounts");
+        }
+    }
+}

--- a/Hippo.Core/Models/GroupModel.cs
+++ b/Hippo.Core/Models/GroupModel.cs
@@ -8,27 +8,31 @@ namespace Hippo.Core.Models
         public int Id { get; set; }
         public string Name { get; set; } = "";
         public string DisplayName { get; set; } = "";
+        public string Data { get; set; } = "";
 
         public List<GroupAccountModel> Admins { get; set; } = new();
 
-        public static Expression<Func<Group, GroupModel>> Projection
+        public static Expression<Func<Group, GroupModel>> GetProjection(bool isClusterOrSystemAdmin, int currentUserId)
         {
-            get
+
+            return g => new GroupModel
             {
-                return g => new GroupModel 
-                { 
-                    Id = g.Id, 
-                    DisplayName = g.DisplayName, 
-                    Name = g.Name,
-                    Admins = g.AdminAccounts
-                        .Select(a => new GroupAccountModel 
-                        { 
-                            Kerberos = a.Kerberos,
-                            Name = a.Name,
-                            Email = a.Email
-                        }).ToList(),
-                };
-            }
+                Id = g.Id,
+                DisplayName = g.DisplayName,
+                Name = g.Name,
+                Admins = g.AdminAccounts
+                    .Select(a => new GroupAccountModel
+                    {
+                        Kerberos = a.Kerberos,
+                        Name = a.Name,
+                        Email = a.Email
+                    }).ToList(),
+                Data = isClusterOrSystemAdmin
+                    || g.AdminAccounts.Any(a => a.OwnerId == currentUserId)
+                    || g.MemberAccounts.Any(a => a.OwnerId == currentUserId)
+                    ? g.Data : null
+            };
+
         }
     }
 

--- a/Hippo.Core/Models/GroupModel.cs
+++ b/Hippo.Core/Models/GroupModel.cs
@@ -12,7 +12,7 @@ namespace Hippo.Core.Models
 
         public List<GroupAccountModel> Admins { get; set; } = new();
 
-        public static Expression<Func<Group, GroupModel>> GetProjection(bool isClusterOrSystemAdmin, int currentUserId)
+        public static Expression<Func<Group, GroupModel>> GetProjection(bool isClusterOrSystemAdmin, int currentUserId = 0)
         {
 
             return g => new GroupModel

--- a/Hippo.Core/Services/AccountSyncService.cs
+++ b/Hippo.Core/Services/AccountSyncService.cs
@@ -55,7 +55,7 @@ namespace Hippo.Core.Services
                 await _dbContext.Database.ExecuteSqlRawAsync("TRUNCATE TABLE [TempGroups]");
                 await _dbContext.Database.ExecuteSqlRawAsync("TRUNCATE TABLE [TempKerberos]");
                 await _dbContext.BulkInsertAsync(puppetData.Users.Select(u => new TempKerberos { Kerberos = u.Kerberos }));
-                await _dbContext.BulkInsertAsync(puppetData.GroupsWithSponsors.Select(g => new TempGroup { Group = g }));
+                await _dbContext.BulkInsertAsync(puppetData.GroupsWithSponsors.Select(g => new TempGroup { Group = g.Name }));
 
                 var mapKerbsToUserIds = await _dbContext.Users
                     .Where(u => _dbContext.TempKerberos.Any(tg => tg.Kerberos == u.Kerberos))
@@ -74,11 +74,18 @@ namespace Hippo.Core.Services
                         ClusterId = cluster.Id,
                         CreatedOn = now,
                         UpdatedOn = now,
+                        Data = u.Data
                     })
                     .Where(a => IsValid(a))
                     .ToArray();
                 var desiredGroups = puppetData.GroupsWithSponsors
-                    .Select(groupName => new Group { Name = groupName, DisplayName = groupName, ClusterId = cluster.Id })
+                    .Select(g => new Group 
+                    {
+                        Name = g.Name, 
+                        DisplayName = g.Name, 
+                        ClusterId = cluster.Id, 
+                        Data = g.Data 
+                    })
                     .Where(g => IsValid(g))
                     .ToArray();
 

--- a/Hippo.Core/Services/PuppetService.cs
+++ b/Hippo.Core/Services/PuppetService.cs
@@ -109,7 +109,6 @@ namespace Hippo.Core.Services
             {
                 var puppetUser = new PuppetUser { Kerberos = kvp.Key.ToString() };
                 var userNode = kvp.Value as Dictionary<object, object>;
-                userNode.Remove("password");
 
                 puppetUser.Name = userNode.GetString("fullname");
                 puppetUser.Email = userNode.GetString("email");
@@ -121,6 +120,11 @@ namespace Hippo.Core.Services
                 {
                     puppetUser.SponsorForGroups = groups.ToArray();
                 }
+
+                // remove fields we don't want stored in Data json property
+                userNode.Remove("password");
+                userNode.Remove("fullname");
+                userNode.Remove("email");
                 puppetUser.Data = _jsonSerializer.Serialize(userNode);
 
                 data.Users.Add(puppetUser);

--- a/Hippo.Web/ClientApp/src/Shared/ObjectTree.tsx
+++ b/Hippo.Web/ClientApp/src/Shared/ObjectTree.tsx
@@ -1,0 +1,60 @@
+import React, { useState } from "react";
+import { ListGroup, ListGroupItem, Collapse } from "reactstrap";
+
+interface ObjectTreeProps {
+  obj: Record<string, any>;
+}
+
+const ObjectTree: React.FC<ObjectTreeProps> = ({ obj }) => {
+  const [expanded, setExpanded] = useState<{ [key: string]: boolean }>({});
+
+  const toggle = (event: React.MouseEvent) => {
+    const id = event.currentTarget.getAttribute("id");
+    setExpanded((prevState) => ({ ...prevState, [id]: !prevState[id] }));
+  };
+
+  const renderItems = (
+    obj: Record<string, any>,
+    parentId?: string,
+    level = 0,
+  ) => {
+    const keys = Object.keys(obj);
+    return keys.map((key) => {
+      const value = obj[key];
+      const id = `${key}-${parentId ?? "top"}`;
+      const isObject = typeof value === "object" && value;
+      const item = (
+        <React.Fragment key={id}>
+          <ListGroupItem className="border-top-0 border-bottom-0 border-end-0">
+            <div
+              style={isObject ? { cursor: "pointer" } : {}}
+              id={id}
+              onClick={toggle}
+            >
+              {isObject && (
+                <i
+                  className={
+                    expanded[id] ? "fas fa-caret-down" : "fas fa-caret-right"
+                  }
+                ></i>
+              )}{" "}
+              {key}
+              {!isObject && `: ${value}`}
+            </div>
+            {isObject && (
+              <Collapse isOpen={expanded[id]}>
+                {renderItems(value, id, level + 1)}
+              </Collapse>
+            )}
+          </ListGroupItem>
+        </React.Fragment>
+      );
+
+      return item;
+    });
+  };
+
+  return <ListGroup flush>{renderItems(obj)}</ListGroup>;
+};
+
+export default ObjectTree;

--- a/Hippo.Web/ClientApp/src/Shared/ObjectTree.tsx
+++ b/Hippo.Web/ClientApp/src/Shared/ObjectTree.tsx
@@ -25,7 +25,10 @@ const ObjectTree: React.FC<ObjectTreeProps> = ({ obj }) => {
       const isObject = typeof value === "object" && value;
       const item = (
         <React.Fragment key={id}>
-          <ListGroupItem className="border-top-0 border-bottom-0 border-end-0">
+          <ListGroupItem
+            className="border-top-0 border-bottom-0 border-end-0"
+            style={{ paddingRight: 0, paddingTop: 2, paddingBottom: 2 }}
+          >
             <div
               style={isObject ? { cursor: "pointer" } : {}}
               id={id}

--- a/Hippo.Web/ClientApp/src/components/Account/AccountInfo.tsx
+++ b/Hippo.Web/ClientApp/src/components/Account/AccountInfo.tsx
@@ -1,7 +1,12 @@
 import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import AppContext from "../../Shared/AppContext";
-import { AddToGroupModel, GroupModel, RawRequestModel } from "../../types";
+import {
+  AddToGroupModel,
+  GroupModel,
+  RawGroupModel,
+  RawRequestModel,
+} from "../../types";
 import { GroupInfo } from "../Group/GroupInfo";
 import { GroupLookup } from "../Group/GroupLookup";
 import { CardColumns } from "reactstrap";
@@ -10,6 +15,7 @@ import { usePromiseNotification } from "../../util/Notifications";
 import {
   authenticatedFetch,
   parseBadRequest,
+  parseRawGroupModel,
   parseRawRequestModel,
 } from "../../util/api";
 import { notEmptyOrFalsey } from "../../util/ValueChecks";
@@ -38,11 +44,13 @@ export const AccountInfo = () => {
 
       if (response.ok) {
         setGroups(
-          ((await response.json()) as GroupModel[]).filter(
-            (g) =>
-              !currentGroups.some((cg) => cg.id === g.id) &&
-              !currentOpenRequests.some((r) => r.groupModel.id === g.id),
-          ),
+          ((await response.json()) as RawGroupModel[])
+            .filter(
+              (g) =>
+                !currentGroups.some((cg) => cg.id === g.id) &&
+                !currentOpenRequests.some((r) => r.groupModel.id === g.id),
+            )
+            .map(parseRawGroupModel),
         );
       } else {
         alert("Error fetching groups");

--- a/Hippo.Web/ClientApp/src/components/Account/ActiveAccounts.tsx
+++ b/Hippo.Web/ClientApp/src/components/Account/ActiveAccounts.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from "react";
+import { useEffect, useState, useMemo, useCallback } from "react";
 import { useParams } from "react-router-dom";
 import { AccountModel, RawAccountModel } from "../../types";
 import { authenticatedFetch, parseRawAccountModel } from "../../util/api";
@@ -6,11 +6,80 @@ import { ReactTable } from "../../Shared/ReactTable";
 import { Column } from "react-table";
 import { GroupNameWithTooltip } from "../Group/GroupNameWithTooltip";
 import { getGroupModelString } from "../../util/StringHelpers";
+import { useConfirmationDialog } from "../../Shared/ConfirmationDialog";
+import ObjectTree from "../../Shared/ObjectTree";
 
 export const ActiveAccounts = () => {
   const [accounts, setAccounts] = useState<AccountModel[]>();
+  const [viewing, setViewing] = useState<number>();
 
   const { cluster } = useParams();
+
+  const [showDetails] = useConfirmationDialog(
+    {
+      title: "Account Details",
+      message: () => {
+        const account = accounts.find((a) => a.id === viewing);
+        return (
+          <div className="row justify-content-center">
+            <div className="col-md-8">
+              <div className="form-group">
+                <label className="form-label">Name</label>
+                <input
+                  className="form-control"
+                  id="accountDetailsName"
+                  value={account.name}
+                  readOnly
+                ></input>
+              </div>
+              <div className="form-group">
+                <label className="form-label">Email</label>
+                <input
+                  className="form-control"
+                  id="accountDetailsEmail"
+                  value={account.email}
+                  readOnly
+                ></input>
+              </div>
+              <div className="form-group">
+                <label className="form-label">Kerberos</label>
+                <input
+                  className="form-control"
+                  id="accountDetailsKerberos"
+                  value={account.kerberos}
+                  readOnly
+                ></input>
+              </div>
+              <div className="form-group">
+                <label className="form-label">Updated On</label>
+                <input
+                  className="form-control"
+                  id="accountDetailsUpdatedOn"
+                  value={new Date(account.updatedOn).toLocaleDateString()}
+                  readOnly
+                ></input>
+              </div>
+              <div className="form-group">
+                <label className="form-label">Details</label>
+                <ObjectTree obj={account.data} />
+              </div>
+            </div>
+          </div>
+        );
+      },
+      buttons: ["OK"],
+    },
+    [accounts, viewing],
+  );
+
+  const handleDetails = useCallback(
+    async (account: AccountModel) => {
+      setViewing(account.id);
+      await showDetails();
+      setViewing(undefined);
+    },
+    [showDetails],
+  );
 
   const columns: Column<AccountModel>[] = useMemo(
     () => [
@@ -53,8 +122,21 @@ export const ActiveAccounts = () => {
         accessor: (row) => new Date(row.updatedOn).toLocaleDateString(),
         sortable: true,
       },
+      {
+        Header: "Action",
+        Cell: (props) => (
+          <>
+            <button
+              onClick={() => handleDetails(props.row.original)}
+              className="btn btn-primary"
+            >
+              {viewing === props.row.original.id ? "Viewing..." : "Details"}
+            </button>
+          </>
+        ),
+      },
     ],
-    [],
+    [handleDetails, viewing],
   );
 
   const accountsData = useMemo(() => accounts ?? [], [accounts]);

--- a/Hippo.Web/ClientApp/src/components/Account/ActiveAccounts.tsx
+++ b/Hippo.Web/ClientApp/src/components/Account/ActiveAccounts.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useMemo } from "react";
 import { useParams } from "react-router-dom";
-import { AccountModel } from "../../types";
-import { authenticatedFetch } from "../../util/api";
+import { AccountModel, RawAccountModel } from "../../types";
+import { authenticatedFetch, parseRawAccountModel } from "../../util/api";
 import { ReactTable } from "../../Shared/ReactTable";
 import { Column } from "react-table";
 import { GroupNameWithTooltip } from "../Group/GroupNameWithTooltip";
@@ -54,7 +54,7 @@ export const ActiveAccounts = () => {
         sortable: true,
       },
     ],
-    []
+    [],
   );
 
   const accountsData = useMemo(() => accounts ?? [], [accounts]);
@@ -62,11 +62,15 @@ export const ActiveAccounts = () => {
   useEffect(() => {
     const fetchAccounts = async () => {
       const response = await authenticatedFetch(
-        `/api/${cluster}/account/active`
+        `/api/${cluster}/account/active`,
       );
 
       if (response.ok) {
-        setAccounts(await response.json());
+        setAccounts(
+          ((await response.json()) as RawAccountModel[]).map(
+            parseRawAccountModel,
+          ),
+        );
       }
     };
 
@@ -85,7 +89,7 @@ export const ActiveAccounts = () => {
         .map((a) => a.memberOfGroups)
         .flat()
         .filter((g) => g !== null)
-        .map((g) => g.name)
+        .map((g) => g.name),
     ).size;
     return (
       <div className="row justify-content-center">

--- a/Hippo.Web/ClientApp/src/components/Account/RequestForm.tsx
+++ b/Hippo.Web/ClientApp/src/components/Account/RequestForm.tsx
@@ -7,10 +7,12 @@ import {
   AccountCreateModel,
   AccessType,
   RawRequestModel,
+  RawGroupModel,
 } from "../../types";
 import {
   authenticatedFetch,
   parseBadRequest,
+  parseRawGroupModel,
   parseRawRequestModel,
 } from "../../util/api";
 import { usePromiseNotification } from "../../util/Notifications";
@@ -40,10 +42,10 @@ export const RequestForm = () => {
         `/api/${clusterName}/group/groups`,
       );
 
-      const groupsResult = (await response.json()) as GroupModel[];
+      const groupsResult = (await response.json()) as RawGroupModel[];
 
       if (response.ok) {
-        setGroups(groupsResult);
+        setGroups(groupsResult.map(parseRawGroupModel));
       }
     };
 

--- a/Hippo.Web/ClientApp/src/components/Account/Requests.test.tsx
+++ b/Hippo.Web/ClientApp/src/components/Account/Requests.test.tsx
@@ -1,9 +1,9 @@
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 
 import {
-  fakeAccounts,
+  fakeRawAccounts,
   fakeGroupAdminAppContext,
-  fakeGroups,
+  fakeRawGroups,
   fakeRawRequests,
 } from "../../test/mockData";
 import { responseMap } from "../../test/testHelpers";
@@ -17,7 +17,7 @@ import userEvent from "@testing-library/user-event";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
-const testCluster = fakeAccounts[0].cluster;
+const testCluster = fakeRawAccounts[0].cluster;
 const approveUrl = `/${testCluster}/approve`;
 
 beforeEach(() => {
@@ -33,7 +33,7 @@ beforeEach(() => {
   const groupsResponse = Promise.resolve({
     status: 200,
     ok: true,
-    json: () => Promise.resolve(fakeGroups),
+    json: () => Promise.resolve(fakeRawGroups),
   });
 
   (global as any).Hippo = fakeGroupAdminAppContext;

--- a/Hippo.Web/ClientApp/src/components/Account/Requests.tsx
+++ b/Hippo.Web/ClientApp/src/components/Account/Requests.tsx
@@ -28,8 +28,8 @@ export const Requests = () => {
 
       if (response.ok) {
         setRequests(
-          (await response.json()).map((r: RawRequestModel) =>
-            parseRawRequestModel(r),
+          ((await response.json()) as RawRequestModel[]).map(
+            parseRawRequestModel,
           ),
         );
       }

--- a/Hippo.Web/ClientApp/src/components/Admin/TransferSponsor.tsx
+++ b/Hippo.Web/ClientApp/src/components/Admin/TransferSponsor.tsx
@@ -1,7 +1,11 @@
 import React, { useState } from "react";
 import { useConfirmationDialog } from "../../Shared/ConfirmationDialog";
-import { AccountModel } from "../../types";
-import { authenticatedFetch, parseBadRequest } from "../../util/api";
+import { AccountModel, RawAccountModel } from "../../types";
+import {
+  authenticatedFetch,
+  parseBadRequest,
+  parseRawAccountModel,
+} from "../../util/api";
 import { usePromiseNotification } from "../../util/Notifications";
 import { notEmptyOrFalsey } from "../../util/ValueChecks";
 
@@ -100,7 +104,9 @@ export const TransferSponsor = (props: Props) => {
     const response = await request;
 
     if (response.ok) {
-      const newAccount = (await response.json()) as AccountModel;
+      const newAccount = parseRawAccountModel(
+        (await response.json()) as RawAccountModel,
+      );
       props.transferSponsor(props.account, newAccount);
     }
   };

--- a/Hippo.Web/ClientApp/src/components/Home.test.tsx
+++ b/Hippo.Web/ClientApp/src/components/Home.test.tsx
@@ -1,10 +1,10 @@
 import { MemoryRouter } from "react-router-dom";
 import App from "../App";
 import {
-  fakeAccounts,
+  fakeRawAccounts,
   fakeGroupAdminAppContext,
   fakeAppContextNoAccount,
-  fakeGroups,
+  fakeRawGroups,
 } from "../test/mockData";
 import { responseMap } from "../test/testHelpers";
 import { render, screen, waitFor } from "@testing-library/react";
@@ -13,7 +13,7 @@ import { act } from "react-dom/test-utils";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
-const testCluster = fakeAccounts[0].cluster;
+const testCluster = fakeRawAccounts[0].cluster;
 const myAccountUrl = `/${testCluster}/myaccount`;
 const promise = Promise.resolve(); // void promise for act warning hack
 
@@ -30,11 +30,11 @@ describe("Basic render", () => {
     const groupsResponse = Promise.resolve({
       status: 200,
       ok: true,
-      json: () => Promise.resolve(fakeGroups),
+      json: () => Promise.resolve(fakeRawGroups),
     });
     global.fetch = jest.fn().mockImplementation((x) =>
       responseMap(x, {
-        [`/api/${fakeAccounts[0].cluster}/group/groups`]: groupsResponse,
+        [`/api/${fakeRawAccounts[0].cluster}/group/groups`]: groupsResponse,
       }),
     );
     (global as any).Hippo = fakeGroupAdminAppContext;
@@ -55,14 +55,14 @@ describe("Home Redirect when GroupAdmin", () => {
     const groupsResponse = Promise.resolve({
       status: 200,
       ok: true,
-      json: () => Promise.resolve(fakeGroups),
+      json: () => Promise.resolve(fakeRawGroups),
     });
 
     (global as any).Hippo = fakeGroupAdminAppContext;
 
     global.fetch = jest.fn().mockImplementation((x) =>
       responseMap(x, {
-        [`/api/${fakeAccounts[0].cluster}/group/groups`]: groupsResponse,
+        [`/api/${fakeRawAccounts[0].cluster}/group/groups`]: groupsResponse,
       }),
     );
   });
@@ -104,14 +104,14 @@ describe("Home Redirect no account", () => {
     const groupsResponse = Promise.resolve({
       status: 200,
       ok: true,
-      json: () => Promise.resolve(fakeGroups),
+      json: () => Promise.resolve(fakeRawGroups),
     });
 
     (global as any).Hippo = fakeAppContextNoAccount;
 
     global.fetch = jest.fn().mockImplementation((x) =>
       responseMap(x, {
-        [`/api/${fakeAccounts[0].cluster}/group/groups`]: groupsResponse,
+        [`/api/${fakeRawAccounts[0].cluster}/group/groups`]: groupsResponse,
       }),
     );
   });

--- a/Hippo.Web/ClientApp/src/test/mockData.ts
+++ b/Hippo.Web/ClientApp/src/test/mockData.ts
@@ -1,12 +1,16 @@
 import {
   AppContextShape,
   User,
-  AccountModel,
-  GroupModel,
   ClusterModel,
   RawRequestModel,
+  RawGroupModel,
+  RawAccountModel,
 } from "../types";
-import { parseRawRequestModel } from "../util/api";
+import {
+  parseRawAccountModel,
+  parseRawGroupModel,
+  parseRawRequestModel,
+} from "../util/api";
 
 const fakeUser: User = {
   id: 1,
@@ -28,22 +32,26 @@ const fakeAdminUser: User = {
   name: "Mr Mr Mr Bob Dobalina",
 };
 
-export const fakeGroups: GroupModel[] = [
+export const fakeRawGroups: RawGroupModel[] = [
   {
     id: 1,
     name: "group1",
     displayName: "Group 1",
     admins: [],
+    data: "",
   },
   {
     id: 2,
     name: "group2",
     displayName: "Group 2",
     admins: [],
+    data: "",
   },
 ];
 
-export const fakeAccounts: AccountModel[] = [
+export const fakeGroups = fakeRawGroups.map(parseRawGroupModel);
+
+export const fakeRawAccounts: RawAccountModel[] = [
   {
     id: 1,
     name: "Account 1",
@@ -55,6 +63,7 @@ export const fakeAccounts: AccountModel[] = [
     memberOfGroups: [fakeGroups[0]],
     adminOfGroups: [],
     accessTypes: ["OpenOnDemand", "SshKey"],
+    data: "",
   },
   {
     id: 2,
@@ -67,8 +76,11 @@ export const fakeAccounts: AccountModel[] = [
     memberOfGroups: [fakeGroups[1]],
     adminOfGroups: [],
     accessTypes: ["OpenOnDemand", "SshKey"],
+    data: "",
   },
 ];
+
+export const fakeAccounts = fakeRawAccounts.map(parseRawAccountModel);
 
 export const fakeRawRequests: RawRequestModel[] = [
   {

--- a/Hippo.Web/ClientApp/src/types.ts
+++ b/Hippo.Web/ClientApp/src/types.ts
@@ -18,12 +18,17 @@ export interface GroupAccountModel {
   email: string;
 }
 
-export interface GroupModel {
+export interface RawGroupModel {
   id: number;
   name: string;
   displayName: string;
   admins: GroupAccountModel[];
+  data: string;
 }
+
+export type GroupModel = Omit<RawGroupModel, "data"> & {
+  data: PuppetGroupRecord;
+};
 
 export interface RawRequestModel {
   id: number;
@@ -52,7 +57,7 @@ export type AccountRequestModel = RequestModelCommon & {
 // make RequestMode a union of all possible action-specific RequestModels (currently only one)
 export type RequestModel = AccountRequestModel;
 
-export interface AccountModel {
+export interface RawAccountModel {
   id: number;
   name: string;
   email: string;
@@ -64,7 +69,12 @@ export interface AccountModel {
   adminOfGroups: GroupModel[];
   updatedOn: string;
   accessTypes: AccessType[];
+  data: string;
 }
+
+export type AccountModel = Omit<RawAccountModel, "data"> & {
+  data: PuppetUserRecord;
+};
 
 export interface AccountCreateModel {
   groupId: number;
@@ -115,3 +125,90 @@ export interface ClusterModel {
 
 export type ModelState = Record<string, string>;
 export type BadRequest = string | ModelState;
+
+// types used by puppet records...
+export type DataQuota = string;
+export type UInt32 = number;
+export type SlurmQOSFlag = string;
+export type KerberosID = string;
+export type Email = string;
+export type LinuxUID = UInt32;
+export type LinuxGID = UInt32;
+export type Shell = string;
+export type PuppetAbsent = "absent";
+export type PuppetEnsure = "present" | PuppetAbsent;
+export type PuppetMembership = "inclusive" | "minimum";
+
+export interface PuppetAutofs {
+  nas: string;
+  path: string;
+  options?: string;
+}
+
+export interface PuppetZFS {
+  quota: DataQuota;
+}
+
+export interface PuppetUserStorage {
+  zfs: PuppetZFS | boolean;
+  autofs?: PuppetAutofs;
+}
+
+export interface SlurmQOSTRES {
+  cpus?: UInt32;
+  gpus?: UInt32;
+  mem?: DataQuota;
+}
+
+export interface SlurmQOS {
+  group?: SlurmQOSTRES;
+  user?: SlurmQOSTRES;
+  job?: SlurmQOSTRES;
+  priority?: number;
+  flags?: Set<SlurmQOSFlag>;
+}
+
+export interface SlurmPartition {
+  qos: SlurmQOS | string;
+}
+
+export interface SlurmRecord {
+  account?: KerberosID | Set<KerberosID>;
+  partitions?: Record<string, SlurmPartition>;
+  max_jobs?: UInt32;
+}
+
+export interface PuppetUserRecord {
+  fullname: string;
+  email: Email;
+  uid: LinuxUID;
+  gid: LinuxGID;
+  groups?: Set<KerberosID>;
+  group_sudo?: KerberosID[];
+  shell?: Shell;
+  tag?: Set<string>;
+  home?: string;
+  expiry?: Date | PuppetAbsent;
+  ensure?: PuppetEnsure;
+  membership?: PuppetMembership;
+  storage?: PuppetUserStorage;
+  slurm?: SlurmRecord;
+}
+
+export interface PuppetGroupStorage {
+  name: string;
+  owner: KerberosID;
+  group?: KerberosID;
+  autofs?: PuppetAutofs;
+  zfs?: PuppetZFS | boolean;
+  globus?: boolean;
+}
+
+export interface PuppetGroupRecord {
+  gid: LinuxGID;
+  sponsors?: KerberosID[];
+  ensure?: PuppetEnsure;
+  tag?: Set<string>;
+  storage?: PuppetGroupStorage[];
+  slurm?: SlurmRecord;
+}

--- a/Hippo.Web/ClientApp/src/util/api.ts
+++ b/Hippo.Web/ClientApp/src/util/api.ts
@@ -1,6 +1,10 @@
 import {
+  AccountModel,
   AppContextShape,
+  GroupModel,
   ModelState,
+  RawAccountModel,
+  RawGroupModel,
   RawRequestModel,
   RequestModel,
 } from "../types";
@@ -47,8 +51,46 @@ export const tryParseJSONObject = (val: string) => {
 };
 
 export const parseRawRequestModel = (rawRequest: RawRequestModel) => {
-  return {
-    ...rawRequest,
-    data: rawRequest.data && JSON.parse(rawRequest.data),
-  } as RequestModel;
+  try {
+    return {
+      ...rawRequest,
+      data: rawRequest.data && JSON.parse(rawRequest.data),
+    } as RequestModel;
+  } catch (error) {
+    console.log(error);
+    return {
+      ...rawRequest,
+      data: undefined,
+    } as RequestModel;
+  }
+};
+
+export const parseRawGroupModel = (rawGroup: RawGroupModel) => {
+  try {
+    return {
+      ...rawGroup,
+      data: rawGroup.data && JSON.parse(rawGroup.data),
+    } as GroupModel;
+  } catch (error) {
+    console.log(error);
+    return {
+      ...rawGroup,
+      data: undefined,
+    } as GroupModel;
+  }
+};
+
+export const parseRawAccountModel = (rawAccount: RawAccountModel) => {
+  try {
+    return {
+      ...rawAccount,
+      data: rawAccount.data && JSON.parse(rawAccount.data),
+    } as AccountModel;
+  } catch (error) {
+    console.log(error);
+    return {
+      ...rawAccount,
+      data: undefined,
+    } as AccountModel;
+  }
 };

--- a/Hippo.Web/Controllers/GroupController.cs
+++ b/Hippo.Web/Controllers/GroupController.cs
@@ -55,29 +55,34 @@ public class GroupController : SuperController
 
     [Authorize(Policy = AccessCodes.ClusterAdminAccess)]
     [HttpPost]
-    public async Task<IActionResult> Update([FromBody] Group group)
+    public async Task<IActionResult> Update([FromBody] UpdateGroupModel updateGroupModel)
     {
         if (string.IsNullOrWhiteSpace(Cluster))
         {
             return BadRequest("You must supply a cluster name.");
         }
 
-        if (group.Id == 0)
+        if (updateGroupModel.Id == 0)
         {
             return BadRequest("You must specify an Id when updating a group.");
         }
 
         var existingGroup = await _dbContext.Groups
             .Where(g => g.Cluster.Name == Cluster)
-            .SingleOrDefaultAsync(g => g.Id == group.Id);
+            .SingleOrDefaultAsync(g => g.Id == updateGroupModel.Id);
         if (existingGroup == null)
         {
             return BadRequest($"Group does not exist.");
         }
 
-        existingGroup.DisplayName = group.DisplayName;
+        existingGroup.DisplayName = updateGroupModel.DisplayName;
         await _dbContext.SaveChangesAsync();
-        return Ok(existingGroup);
+
+        var groupModel = await _dbContext.Groups
+            .Where(g => g.Id == updateGroupModel.Id)
+            .Select(GroupModel.GetProjection(true))
+            .SingleAsync();
+        return Ok(groupModel);
     }
 
     [HttpPost]

--- a/Hippo.Web/Controllers/GroupController.cs
+++ b/Hippo.Web/Controllers/GroupController.cs
@@ -39,11 +39,15 @@ public class GroupController : SuperController
             return BadRequest("You must supply a cluster name.");
         }
 
+        var currentUser = await _userService.GetCurrentUser();
+        var permissions = await _userService.GetCurrentPermissionsAsync();
+        var isClusterOrSystemAdmin = permissions.IsClusterOrSystemAdmin(Cluster);
+
         var groups = await _dbContext.Groups
             .AsNoTracking()
             .Where(g => g.Cluster.Name == Cluster)
             .OrderBy(g => g.DisplayName)
-            .Select(GroupModel.Projection)
+            .Select(GroupModel.GetProjection(isClusterOrSystemAdmin, currentUser.Id))
             .ToArrayAsync();
 
         return Ok(groups);

--- a/Hippo.Web/Models/UpdateGroupModel.cs
+++ b/Hippo.Web/Models/UpdateGroupModel.cs
@@ -1,0 +1,8 @@
+﻿namespace Hippo.Web.Models
+{
+    public class UpdateGroupModel
+    {
+        public int Id { get; set; }
+        public string DisplayName { get; set; } = String.Empty;
+    }
+}


### PR DESCRIPTION
I went with a generic collapsible `ObjectTree` component for displaying resource data. Not sure if @cydoval should have a go yet at prettying it up. Maybe @acgetchell will have some feedback?

Group data:
![image](https://github.com/ucdavis/hippo/assets/2398955/88a2ea7c-31a7-444b-820e-074a819a3ea7)

Account data:
![image](https://github.com/ucdavis/hippo/assets/2398955/77b5e4b3-c379-4788-9d1b-22eaaaf7672f)

