### PR TITLE
Data serialization refactor

### DIFF
--- a/Hippo.Core/Data/AppDbContext.cs
+++ b/Hippo.Core/Data/AppDbContext.cs
@@ -45,17 +45,17 @@ namespace Hippo.Core.Data
         protected override void OnModelCreating(ModelBuilder builder)
         {
             base.OnModelCreating(builder);
-            Account.OnModelCreating(builder);
+            Account.OnModelCreating(builder, this);
             User.OnModelCreating(builder);
             History.OnModelCreating(builder);
             Cluster.OnModelCreating(builder);
-            Group.OnModelCreating(builder);
+            Group.OnModelCreating(builder, this);
             Role.OnModelCreating(builder);
             Permission.OnModelCreating(builder);
-            Request.OnModelCreating(builder);
+            Request.OnModelCreating(builder, this);
             Domain.GroupAdminAccount.OnModelCreating(builder);
             Domain.GroupMemberAccount.OnModelCreating(builder);
-            QueuedEvent.OnModelCreating(builder);
+            QueuedEvent.OnModelCreating(builder, this);
             AccessType.OnModelCreating(builder);
         }
     }

--- a/Hippo.Core/Domain/Account.cs
+++ b/Hippo.Core/Domain/Account.cs
@@ -2,7 +2,10 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Text;
+using System.Text.Json;
 using System.Text.Json.Serialization;
+using Hippo.Core.Data;
+using Hippo.Core.Extensions;
 using Microsoft.EntityFrameworkCore;
 
 namespace Hippo.Core.Domain
@@ -39,7 +42,8 @@ namespace Hippo.Core.Domain
 
         public string SshKey { get; set; }
 
-        public string Data { get; set; }
+        // TODO: When C# gets type unions, update this to something more strongly typed
+        public JsonElement? Data { get; set; }
 
         public int? OwnerId { get; set; }
         public User Owner { get; set; }
@@ -57,7 +61,7 @@ namespace Hippo.Core.Domain
         [JsonIgnore]
         public List<AccessType> AccessTypes { get; set; } = new();
         
-        internal static void OnModelCreating(ModelBuilder modelBuilder)
+        internal static void OnModelCreating(ModelBuilder modelBuilder, DbContext dbContext)
         {
             modelBuilder.Entity<Account>().HasQueryFilter(a => a.Cluster.IsActive);
             modelBuilder.Entity<Account>().HasIndex(a => a.CreatedOn);
@@ -66,6 +70,7 @@ namespace Hippo.Core.Domain
             modelBuilder.Entity<Account>().HasIndex(a => a.Name);
             modelBuilder.Entity<Account>().HasIndex(a => a.Email);
             modelBuilder.Entity<Account>().HasIndex(a => a.Kerberos);
+            modelBuilder.Entity<Account>().Property(g => g.Data).HasJsonConversion(dbContext);
         }
     }
 }

--- a/Hippo.Core/Domain/Group.cs
+++ b/Hippo.Core/Domain/Group.cs
@@ -1,6 +1,9 @@
 using System.ComponentModel.DataAnnotations;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.EntityFrameworkCore;
+using Hippo.Core.Extensions;
+using Hippo.Core.Data;
 
 namespace Hippo.Core.Domain
 {
@@ -20,7 +23,8 @@ namespace Hippo.Core.Domain
         public int ClusterId { get; set; }
         public Cluster Cluster { get; set; }
 
-        public string Data { get; set; } = "";
+        // TODO: When C# gets type unions, update this to something more strongly typed
+        public JsonElement? Data { get; set; }
 
         [JsonIgnore]
         public List<Account> MemberAccounts { get; set; } = new();
@@ -28,10 +32,11 @@ namespace Hippo.Core.Domain
         [JsonIgnore]
         public List<Account> AdminAccounts { get; set; } = new();
 
-        internal static void OnModelCreating(ModelBuilder modelBuilder)
+        internal static void OnModelCreating(ModelBuilder modelBuilder, DbContext dbContext)
         {
             modelBuilder.Entity<Group>().HasQueryFilter(g => g.Cluster.IsActive);
             modelBuilder.Entity<Group>().HasIndex(g => new { g.ClusterId, g.Name }).IsUnique();
+            modelBuilder.Entity<Group>().Property(g => g.Data).HasJsonConversion(dbContext);
 
             modelBuilder.Entity<Account>()
                 .HasMany(a => a.MemberOfGroups)

--- a/Hippo.Core/Domain/QueuedEvent.cs
+++ b/Hippo.Core/Domain/QueuedEvent.cs
@@ -1,4 +1,7 @@
 using System.ComponentModel.DataAnnotations;
+using Hippo.Core.Data;
+using Hippo.Core.Extensions;
+using Hippo.Core.Models;
 using Microsoft.EntityFrameworkCore;
 
 namespace Hippo.Core.Domain;
@@ -10,14 +13,14 @@ public class QueuedEvent
     public string Action { get; set; } = "";
     [MaxLength(50)]
     public string Status { get; set; } = "";
-    public string Data { get; set; } = "";
+    public QueuedEventDataModel Data { get; set; }
     public string ErrorMessage { get; set; } = "";
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
     public int? RequestId { get; set; }
     public Request Request { get; set; }
 
-    internal static void OnModelCreating(ModelBuilder modelBuilder)
+    internal static void OnModelCreating(ModelBuilder modelBuilder, DbContext dbContext)
     {
         modelBuilder.Entity<QueuedEvent>().HasIndex(qe => qe.Action);
         modelBuilder.Entity<QueuedEvent>().HasIndex(qe => qe.Status);
@@ -27,6 +30,7 @@ public class QueuedEvent
             .WithMany(r => r.QueuedEvents)
             .HasForeignKey(qe => qe.RequestId)
             .OnDelete(DeleteBehavior.Restrict);
+        modelBuilder.Entity<QueuedEvent>().Property(g => g.Data).HasJsonConversion(dbContext);
     }
 
     public static class Actions
@@ -35,8 +39,8 @@ public class QueuedEvent
         public const string UpdateSshKey = "UpdateSshKey";
         public const string AddAccountToGroup = "AddAccountToGroup";
 
-        public const string RegexPattern = CreateAccount 
-            + "|" + UpdateSshKey 
+        public const string RegexPattern = CreateAccount
+            + "|" + UpdateSshKey
             + "|" + AddAccountToGroup;
     }
 
@@ -47,17 +51,17 @@ public class QueuedEvent
         public const string Failed = "Failed";
         public const string Canceled = "Canceled";
 
-        public const string RegexPattern = Pending 
-            + "|" + Complete 
-            + "|" + Failed 
+        public const string RegexPattern = Pending
+            + "|" + Complete
+            + "|" + Failed
             + "|" + Canceled;
 
-        public static List<string> AllStatuses = new() 
-        { 
-            Pending, 
-            Complete, 
-            Failed, 
-            Canceled 
+        public static List<string> AllStatuses = new()
+        {
+            Pending,
+            Complete,
+            Failed,
+            Canceled
         };
     }
 }

--- a/Hippo.Core/Extensions/RequestExtensions.cs
+++ b/Hippo.Core/Extensions/RequestExtensions.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Hippo.Core.Domain;
 using Hippo.Core.Models;
+using Hippo.Core.Utilities;
 
 namespace Hippo.Core.Extensions;
 
@@ -11,7 +12,7 @@ public static class RequestExtensions
         if (!AccountRequestDataModel.ValidActions.Contains(request.Action))
             throw new ArgumentException($"Invalid data type ({nameof(AccountRequestDataModel)}) for action {request.Action}");
 
-        request.Data = JsonSerializer.Serialize(data, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+        request.Data = JsonHelper.ConvertToJsonElement(data);
 
         return request;
     }
@@ -21,9 +22,9 @@ public static class RequestExtensions
         if (!AccountRequestDataModel.ValidActions.Contains(request.Action))
             throw new InvalidOperationException($"Cannot get {nameof(AccountRequestDataModel.SshKey)} from {nameof(request.Data)} for action {request.Action}");
 
-        var data = string.IsNullOrWhiteSpace(request.Data)
-            ? new ()
-            : JsonSerializer.Deserialize<AccountRequestDataModel>(request.Data, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        var data = request.Data == null
+            ? new()
+            : JsonHelper.ConvertFromJsonElement<AccountRequestDataModel>(request.Data);
 
         return data;
     }

--- a/Hippo.Core/Extensions/ValueConversionExtensions.cs
+++ b/Hippo.Core/Extensions/ValueConversionExtensions.cs
@@ -1,0 +1,45 @@
+using System.Text.Json;
+using Hippo.Core.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace Hippo.Core.Extensions;
+
+public static class ValueConversionExtensions
+{
+    private static JsonSerializerOptions _serializeOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+    private static JsonSerializerOptions _deserializeOptions = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+
+    public static PropertyBuilder<T> HasJsonConversion<T>(this PropertyBuilder<T> propertyBuilder, DbContext dbContext)
+    {
+        ValueConverter<T, string> converter = new ValueConverter<T, string>
+        (
+            v => EqualityComparer<T>.Default.Equals(v, default) ? "" : JsonSerializer.Serialize(v, _serializeOptions),
+            v => string.IsNullOrWhiteSpace(v) ? default : JsonSerializer.Deserialize<T>(v, _deserializeOptions)
+        );
+
+        // ValueComparer ensures the client-side value plays nicely with the change tracker. The Serialize/Deserialize stuff might cause
+        // performance issues when a given DbSet holds a lot of records in the change tracker. But we generally don't perform updates or 
+        // change tracking on large data sets.
+        ValueComparer<T> comparer = new ValueComparer<T>
+        (
+            (l, r) => JsonSerializer.Serialize(l, _serializeOptions) == JsonSerializer.Serialize(r, _serializeOptions),
+            v => v == null ? 0 : JsonSerializer.Serialize(v, _serializeOptions).GetHashCode(),
+            v => JsonSerializer.Deserialize<T>(JsonSerializer.Serialize(v, _serializeOptions), _deserializeOptions)
+        );
+
+        propertyBuilder.HasConversion(converter);
+        propertyBuilder.Metadata.SetValueConverter(converter);
+        propertyBuilder.Metadata.SetValueComparer(comparer);
+
+        // Not sure if there is a better way to determine what column type to use
+        if (dbContext.Database.IsSqlite())
+            propertyBuilder.HasColumnType("TEXT");
+        else
+            propertyBuilder.HasColumnType("nvarchar(max)");
+
+        return propertyBuilder;
+    }
+}

--- a/Hippo.Core/Models/GroupModel.cs
+++ b/Hippo.Core/Models/GroupModel.cs
@@ -1,4 +1,5 @@
 using System.Linq.Expressions;
+using System.Text.Json;
 using Hippo.Core.Domain;
 
 namespace Hippo.Core.Models
@@ -8,7 +9,7 @@ namespace Hippo.Core.Models
         public int Id { get; set; }
         public string Name { get; set; } = "";
         public string DisplayName { get; set; } = "";
-        public string Data { get; set; } = "";
+        public JsonElement? Data { get; set; }
 
         public List<GroupAccountModel> Admins { get; set; } = new();
 

--- a/Hippo.Core/Models/QueuedEventModel.cs
+++ b/Hippo.Core/Models/QueuedEventModel.cs
@@ -28,7 +28,7 @@ public class QueuedEventModel
             Id = queuedEvent.Id,
             Action = queuedEvent.Action,
             Status = queuedEvent.Status,
-            Data = JsonSerializer.Deserialize<QueuedEventDataModel>(queuedEvent.Data, new JsonSerializerOptions { PropertyNameCaseInsensitive = true }),
+            Data = queuedEvent.Data,
             CreatedAt = queuedEvent.CreatedAt,
             UpdatedAt = queuedEvent.UpdatedAt
         };

--- a/Hippo.Core/Models/RequestModel.cs
+++ b/Hippo.Core/Models/RequestModel.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.Linq.Expressions;
+using System.Text.Json;
 using Hippo.Core.Data;
 using Hippo.Core.Domain;
 using Hippo.Core.Validation;
@@ -17,7 +18,7 @@ namespace Hippo.Core.Models
 
         public GroupModel GroupModel { get; set; } = new();
 
-        public string Data { get; set; }
+        public JsonElement? Data { get; set; }
     }
 
     public class AccountRequestDataModel

--- a/Hippo.Core/Services/PuppetService.cs
+++ b/Hippo.Core/Services/PuppetService.cs
@@ -5,6 +5,7 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Security.Cryptography;
 using System.Text.Json;
 using Hippo.Core.Models.Settings;
+using Hippo.Core.Utilities;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
@@ -94,7 +95,7 @@ namespace Hippo.Core.Services
                     data.GroupsWithSponsors.Add(new PuppetGroup 
                     {
                         Name = groupName, 
-                        Data = JsonSerializer.Deserialize<JsonElement>(_yamlDotNetJsonSerializer.Serialize(groupNode))
+                        Data = JsonHelper.DeserializeToJsonElement(_yamlDotNetJsonSerializer.Serialize(groupNode))
                     });
                     foreach (var user in sponsors)
                     {
@@ -126,7 +127,7 @@ namespace Hippo.Core.Services
                 userNode.Remove("password");
                 userNode.Remove("fullname");
                 userNode.Remove("email");
-                puppetUser.Data = JsonSerializer.Deserialize<JsonElement>(_yamlDotNetJsonSerializer.Serialize(userNode));
+                puppetUser.Data = JsonHelper.DeserializeToJsonElement(_yamlDotNetJsonSerializer.Serialize(userNode));
 
                 data.Users.Add(puppetUser);
             }

--- a/Hippo.Core/Services/PuppetService.cs
+++ b/Hippo.Core/Services/PuppetService.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Cryptography;
+using System.Text.Json;
 using Hippo.Core.Models.Settings;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
@@ -21,12 +22,12 @@ namespace Hippo.Core.Services
     {
         private readonly PuppetSettings _settings;
         private readonly IMemoryCache _memoryCache;
-        private readonly ISerializer _jsonSerializer;
+        private readonly ISerializer _yamlDotNetJsonSerializer;
         public PuppetService(IOptions<PuppetSettings> settings, IMemoryCache memoryCache)
         {
             _settings = settings.Value;
             _memoryCache = memoryCache;
-            _jsonSerializer = new SerializerBuilder()
+            _yamlDotNetJsonSerializer = new SerializerBuilder()
                 .JsonCompatible()
                 .Build();
         }
@@ -93,7 +94,7 @@ namespace Hippo.Core.Services
                     data.GroupsWithSponsors.Add(new PuppetGroup 
                     {
                         Name = groupName, 
-                        Data = _jsonSerializer.Serialize(groupNode) 
+                        Data = JsonSerializer.Deserialize<JsonElement>(_yamlDotNetJsonSerializer.Serialize(groupNode))
                     });
                     foreach (var user in sponsors)
                     {
@@ -125,7 +126,7 @@ namespace Hippo.Core.Services
                 userNode.Remove("password");
                 userNode.Remove("fullname");
                 userNode.Remove("email");
-                puppetUser.Data = _jsonSerializer.Serialize(userNode);
+                puppetUser.Data = JsonSerializer.Deserialize<JsonElement>(_yamlDotNetJsonSerializer.Serialize(userNode));
 
                 data.Users.Add(puppetUser);
             }
@@ -174,13 +175,13 @@ namespace Hippo.Core.Services
         public string Email { get; set; }
         public string[] Groups { get; set; } = new string[] { };
         public string[] SponsorForGroups { get; set; } = new string[] { };
-        public string Data { get; set; }
+        public JsonElement Data { get; set; }
     }
 
     public class PuppetGroup
     {
         public string Name { get; set; }
-        public string Data { get; set; }
+        public JsonElement Data { get; set; }
 
     }
 

--- a/Hippo.Core/Utilities/JsonHelper.cs
+++ b/Hippo.Core/Utilities/JsonHelper.cs
@@ -12,6 +12,11 @@ public static class JsonHelper
         return JsonSerializer.Deserialize<JsonElement>(JsonSerializer.Serialize(value, _serializeOptions), _deserializeOptions);
     }
 
+    public static JsonElement DeserializeToJsonElement(string value)
+    {
+        return JsonSerializer.Deserialize<JsonElement>(value, _deserializeOptions);
+    }
+
     public static T ConvertFromJsonElement<T>(JsonElement? value) where T : class
     {
         return value?.Deserialize<T>(_deserializeOptions);

--- a/Hippo.Core/Utilities/JsonHelper.cs
+++ b/Hippo.Core/Utilities/JsonHelper.cs
@@ -1,0 +1,19 @@
+using System.Text.Json;
+
+namespace Hippo.Core.Utilities;
+
+public static class JsonHelper
+{
+    private static JsonSerializerOptions _serializeOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+    private static JsonSerializerOptions _deserializeOptions = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+
+    public static JsonElement ConvertToJsonElement<T>(T value)
+    {
+        return JsonSerializer.Deserialize<JsonElement>(JsonSerializer.Serialize(value, _serializeOptions), _deserializeOptions);
+    }
+
+    public static T ConvertFromJsonElement<T>(JsonElement? value) where T : class
+    {
+        return value?.Deserialize<T>(_deserializeOptions);
+    }
+}

--- a/Hippo.Web/ClientApp/src/components/Account/AccountInfo.tsx
+++ b/Hippo.Web/ClientApp/src/components/Account/AccountInfo.tsx
@@ -1,23 +1,13 @@
 import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import AppContext from "../../Shared/AppContext";
-import {
-  AddToGroupModel,
-  GroupModel,
-  RawGroupModel,
-  RawRequestModel,
-} from "../../types";
+import { AddToGroupModel, GroupModel, RequestModel } from "../../types";
 import { GroupInfo } from "../Group/GroupInfo";
 import { GroupLookup } from "../Group/GroupLookup";
 import { CardColumns } from "reactstrap";
 import { useConfirmationDialog } from "../../Shared/ConfirmationDialog";
 import { usePromiseNotification } from "../../util/Notifications";
-import {
-  authenticatedFetch,
-  parseBadRequest,
-  parseRawGroupModel,
-  parseRawRequestModel,
-} from "../../util/api";
+import { authenticatedFetch, parseBadRequest } from "../../util/api";
 import { notEmptyOrFalsey } from "../../util/ValueChecks";
 import SshKeyInput from "../../Shared/SshKeyInput";
 import GroupDetails from "../Group/GroupDetails";
@@ -49,14 +39,12 @@ export const AccountInfo = () => {
 
       if (response.ok) {
         setAvailableGroups(
-          ((await response.json()) as RawGroupModel[])
-            .filter(
-              (g) =>
-                !memberOfGroups.some((cg) => cg.id === g.id) &&
-                !adminOfGroups.some((cg) => cg.id === g.id) &&
-                !currentOpenRequests.some((r) => r.groupModel.id === g.id),
-            )
-            .map(parseRawGroupModel),
+          ((await response.json()) as GroupModel[]).filter(
+            (g) =>
+              !memberOfGroups.some((cg) => cg.id === g.id) &&
+              !adminOfGroups.some((cg) => cg.id === g.id) &&
+              !currentOpenRequests.some((r) => r.groupModel.id === g.id),
+          ),
         );
       } else {
         alert("Error fetching groups");
@@ -64,7 +52,7 @@ export const AccountInfo = () => {
     };
 
     fetchGroups();
-  }, [clusterName, currentOpenRequests, memberOfGroups]);
+  }, [adminOfGroups, clusterName, currentOpenRequests, memberOfGroups]);
 
   const [getGroupConfirmation] = useConfirmationDialog<AddToGroupModel>(
     {
@@ -164,14 +152,11 @@ export const AccountInfo = () => {
 
       const response = await request;
       if (response.ok) {
-        const rawRequestModel = (await response.json()) as RawRequestModel;
+        const requestModel = (await response.json()) as RequestModel;
 
         setContext((c) => ({
           ...c,
-          openRequests: [
-            ...c.openRequests,
-            parseRawRequestModel(rawRequestModel),
-          ],
+          openRequests: [...c.openRequests, requestModel],
         }));
         setAvailableGroups((g) =>
           g.filter((g) => g.id !== addToGroupModel.groupId),

--- a/Hippo.Web/ClientApp/src/components/Account/ActiveAccounts.tsx
+++ b/Hippo.Web/ClientApp/src/components/Account/ActiveAccounts.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useMemo, useCallback } from "react";
 import { useParams } from "react-router-dom";
-import { AccountModel, RawAccountModel } from "../../types";
-import { authenticatedFetch, parseRawAccountModel } from "../../util/api";
+import { AccountModel } from "../../types";
+import { authenticatedFetch } from "../../util/api";
 import { ReactTable } from "../../Shared/ReactTable";
 import { Column } from "react-table";
 import { GroupNameWithTooltip } from "../Group/GroupNameWithTooltip";
@@ -148,11 +148,7 @@ export const ActiveAccounts = () => {
       );
 
       if (response.ok) {
-        setAccounts(
-          ((await response.json()) as RawAccountModel[]).map(
-            parseRawAccountModel,
-          ),
-        );
+        setAccounts((await response.json()) as AccountModel[]);
       }
     };
 

--- a/Hippo.Web/ClientApp/src/components/Account/RequestForm.tsx
+++ b/Hippo.Web/ClientApp/src/components/Account/RequestForm.tsx
@@ -6,15 +6,9 @@ import {
   GroupModel,
   AccountCreateModel,
   AccessType,
-  RawRequestModel,
-  RawGroupModel,
+  RequestModel,
 } from "../../types";
-import {
-  authenticatedFetch,
-  parseBadRequest,
-  parseRawGroupModel,
-  parseRawRequestModel,
-} from "../../util/api";
+import { authenticatedFetch, parseBadRequest } from "../../util/api";
 import { usePromiseNotification } from "../../util/Notifications";
 import { GroupLookup } from "../Group/GroupLookup";
 import SshKeyInput from "../../Shared/SshKeyInput";
@@ -42,10 +36,10 @@ export const RequestForm = () => {
         `/api/${clusterName}/group/groups`,
       );
 
-      const groupsResult = (await response.json()) as RawGroupModel[];
+      const groupsResult = (await response.json()) as GroupModel[];
 
       if (response.ok) {
-        setGroups(groupsResult.map(parseRawGroupModel));
+        setGroups(groupsResult);
       }
     };
 
@@ -75,14 +69,11 @@ export const RequestForm = () => {
     const response = await req;
 
     if (response.ok) {
-      const rawRequestModel = (await response.json()) as RawRequestModel;
+      const requestModel = (await response.json()) as RequestModel;
 
       setContext((ctx) => ({
         ...ctx,
-        openRequests: [
-          ...ctx.openRequests,
-          parseRawRequestModel(rawRequestModel),
-        ],
+        openRequests: [...ctx.openRequests, requestModel],
       }));
       navigate(`/${clusterName}/accountstatus`);
     }

--- a/Hippo.Web/ClientApp/src/components/Account/Requests.test.tsx
+++ b/Hippo.Web/ClientApp/src/components/Account/Requests.test.tsx
@@ -1,10 +1,10 @@
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 
 import {
-  fakeRawAccounts,
+  fakeAccounts,
   fakeGroupAdminAppContext,
-  fakeRawGroups,
-  fakeRawRequests,
+  fakeGroups,
+  fakeRequests,
 } from "../../test/mockData";
 import { responseMap } from "../../test/testHelpers";
 
@@ -17,14 +17,14 @@ import userEvent from "@testing-library/user-event";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
-const testCluster = fakeRawAccounts[0].cluster;
+const testCluster = fakeAccounts[0].cluster;
 const approveUrl = `/${testCluster}/approve`;
 
 beforeEach(() => {
   const requestResponse = Promise.resolve({
     status: 200,
     ok: true,
-    json: () => Promise.resolve(fakeRawRequests),
+    json: () => Promise.resolve(fakeRequests),
   });
   const approveResponse = Promise.resolve({
     status: 200,
@@ -33,7 +33,7 @@ beforeEach(() => {
   const groupsResponse = Promise.resolve({
     status: 200,
     ok: true,
-    json: () => Promise.resolve(fakeRawGroups),
+    json: () => Promise.resolve(fakeGroups),
   });
 
   (global as any).Hippo = fakeGroupAdminAppContext;

--- a/Hippo.Web/ClientApp/src/components/Account/Requests.tsx
+++ b/Hippo.Web/ClientApp/src/components/Account/Requests.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useMemo, useCallback } from "react";
-import { RawRequestModel, RequestModel } from "../../types";
+import { RequestModel } from "../../types";
 import { RejectRequest } from "../../Shared/RejectRequest";
-import { authenticatedFetch, parseRawRequestModel } from "../../util/api";
+import { authenticatedFetch } from "../../util/api";
 import { usePromiseNotification } from "../../util/Notifications";
 import { useParams } from "react-router-dom";
 import { ReactTable } from "../../Shared/ReactTable";
@@ -27,11 +27,7 @@ export const Requests = () => {
       );
 
       if (response.ok) {
-        setRequests(
-          ((await response.json()) as RawRequestModel[]).map(
-            parseRawRequestModel,
-          ),
-        );
+        setRequests((await response.json()) as RequestModel[]);
       }
     };
 

--- a/Hippo.Web/ClientApp/src/components/Admin/Groups.tsx
+++ b/Hippo.Web/ClientApp/src/components/Admin/Groups.tsx
@@ -1,12 +1,8 @@
 import { useEffect, useState, useMemo, useCallback } from "react";
 import { useParams } from "react-router-dom";
 import { useConfirmationDialog } from "../../Shared/ConfirmationDialog";
-import { GroupModel, RawGroupModel } from "../../types";
-import {
-  authenticatedFetch,
-  parseBadRequest,
-  parseRawGroupModel,
-} from "../../util/api";
+import { GroupModel } from "../../types";
+import { authenticatedFetch, parseBadRequest } from "../../util/api";
 import { usePromiseNotification } from "../../util/Notifications";
 import { ReactTable } from "../../Shared/ReactTable";
 import { Column } from "react-table";
@@ -75,9 +71,7 @@ export const Groups = () => {
       const response = await authenticatedFetch(`/api/${cluster}/group/groups`);
 
       if (response.ok) {
-        setGroups(
-          ((await response.json()) as RawGroupModel[]).map(parseRawGroupModel),
-        );
+        setGroups((await response.json()) as GroupModel[]);
       } else {
         alert("Error fetching groups");
       }
@@ -113,9 +107,7 @@ export const Groups = () => {
       const response = await req;
 
       if (response.ok) {
-        const updatedGroup = parseRawGroupModel(
-          (await response.json()) as RawGroupModel,
-        );
+        const updatedGroup = (await response.json()) as GroupModel;
         let updatedGroups = [] as GroupModel[];
         //check if the updatedGroup is already in the list
         if (groups?.find((g) => g.id === updatedGroup.id)) {

--- a/Hippo.Web/ClientApp/src/components/Admin/TransferSponsor.tsx
+++ b/Hippo.Web/ClientApp/src/components/Admin/TransferSponsor.tsx
@@ -1,11 +1,7 @@
 import React, { useState } from "react";
 import { useConfirmationDialog } from "../../Shared/ConfirmationDialog";
-import { AccountModel, RawAccountModel } from "../../types";
-import {
-  authenticatedFetch,
-  parseBadRequest,
-  parseRawAccountModel,
-} from "../../util/api";
+import { AccountModel } from "../../types";
+import { authenticatedFetch, parseBadRequest } from "../../util/api";
 import { usePromiseNotification } from "../../util/Notifications";
 import { notEmptyOrFalsey } from "../../util/ValueChecks";
 
@@ -104,9 +100,7 @@ export const TransferSponsor = (props: Props) => {
     const response = await request;
 
     if (response.ok) {
-      const newAccount = parseRawAccountModel(
-        (await response.json()) as RawAccountModel,
-      );
+      const newAccount = (await response.json()) as AccountModel;
       props.transferSponsor(props.account, newAccount);
     }
   };

--- a/Hippo.Web/ClientApp/src/components/Home.test.tsx
+++ b/Hippo.Web/ClientApp/src/components/Home.test.tsx
@@ -1,10 +1,10 @@
 import { MemoryRouter } from "react-router-dom";
 import App from "../App";
 import {
-  fakeRawAccounts,
+  fakeAccounts,
   fakeGroupAdminAppContext,
   fakeAppContextNoAccount,
-  fakeRawGroups,
+  fakeGroups,
 } from "../test/mockData";
 import { responseMap } from "../test/testHelpers";
 import { render, screen, waitFor } from "@testing-library/react";
@@ -13,7 +13,7 @@ import { act } from "react-dom/test-utils";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
-const testCluster = fakeRawAccounts[0].cluster;
+const testCluster = fakeAccounts[0].cluster;
 const myAccountUrl = `/${testCluster}/myaccount`;
 const promise = Promise.resolve(); // void promise for act warning hack
 
@@ -30,11 +30,11 @@ describe("Basic render", () => {
     const groupsResponse = Promise.resolve({
       status: 200,
       ok: true,
-      json: () => Promise.resolve(fakeRawGroups),
+      json: () => Promise.resolve(fakeGroups),
     });
     global.fetch = jest.fn().mockImplementation((x) =>
       responseMap(x, {
-        [`/api/${fakeRawAccounts[0].cluster}/group/groups`]: groupsResponse,
+        [`/api/${fakeAccounts[0].cluster}/group/groups`]: groupsResponse,
       }),
     );
     (global as any).Hippo = fakeGroupAdminAppContext;
@@ -55,14 +55,14 @@ describe("Home Redirect when GroupAdmin", () => {
     const groupsResponse = Promise.resolve({
       status: 200,
       ok: true,
-      json: () => Promise.resolve(fakeRawGroups),
+      json: () => Promise.resolve(fakeGroups),
     });
 
     (global as any).Hippo = fakeGroupAdminAppContext;
 
     global.fetch = jest.fn().mockImplementation((x) =>
       responseMap(x, {
-        [`/api/${fakeRawAccounts[0].cluster}/group/groups`]: groupsResponse,
+        [`/api/${fakeAccounts[0].cluster}/group/groups`]: groupsResponse,
       }),
     );
   });
@@ -100,14 +100,14 @@ describe("Home Redirect no account", () => {
     const groupsResponse = Promise.resolve({
       status: 200,
       ok: true,
-      json: () => Promise.resolve(fakeRawGroups),
+      json: () => Promise.resolve(fakeGroups),
     });
 
     (global as any).Hippo = fakeAppContextNoAccount;
 
     global.fetch = jest.fn().mockImplementation((x) =>
       responseMap(x, {
-        [`/api/${fakeRawAccounts[0].cluster}/group/groups`]: groupsResponse,
+        [`/api/${fakeAccounts[0].cluster}/group/groups`]: groupsResponse,
       }),
     );
   });

--- a/Hippo.Web/ClientApp/src/test/mockData.ts
+++ b/Hippo.Web/ClientApp/src/test/mockData.ts
@@ -2,15 +2,13 @@ import {
   AppContextShape,
   User,
   ClusterModel,
-  RawRequestModel,
-  RawGroupModel,
-  RawAccountModel,
+  GroupModel,
+  PuppetGroupRecord,
+  AccountModel,
+  PuppetUserRecord,
+  RequestModel,
+  AccountRequestDataModel,
 } from "../types";
-import {
-  parseRawAccountModel,
-  parseRawGroupModel,
-  parseRawRequestModel,
-} from "../util/api";
 
 const fakeUser: User = {
   id: 1,
@@ -32,26 +30,24 @@ const fakeAdminUser: User = {
   name: "Mr Mr Mr Bob Dobalina",
 };
 
-export const fakeRawGroups: RawGroupModel[] = [
+export const fakeGroups: GroupModel[] = [
   {
     id: 1,
     name: "group1",
     displayName: "Group 1",
     admins: [],
-    data: "",
+    data: {} as PuppetGroupRecord,
   },
   {
     id: 2,
     name: "group2",
     displayName: "Group 2",
     admins: [],
-    data: "",
+    data: {} as PuppetGroupRecord,
   },
 ];
 
-export const fakeGroups = fakeRawGroups.map(parseRawGroupModel);
-
-export const fakeRawAccounts: RawAccountModel[] = [
+export const fakeAccounts: AccountModel[] = [
   {
     id: 1,
     name: "Account 1",
@@ -63,7 +59,7 @@ export const fakeRawAccounts: RawAccountModel[] = [
     memberOfGroups: [fakeGroups[0]],
     adminOfGroups: [],
     accessTypes: ["OpenOnDemand", "SshKey"],
-    data: "",
+    data: {} as PuppetUserRecord,
   },
   {
     id: 2,
@@ -76,13 +72,11 @@ export const fakeRawAccounts: RawAccountModel[] = [
     memberOfGroups: [fakeGroups[1]],
     adminOfGroups: [],
     accessTypes: ["OpenOnDemand", "SshKey"],
-    data: "",
+    data: {} as PuppetUserRecord,
   },
 ];
 
-export const fakeAccounts = fakeRawAccounts.map(parseRawAccountModel);
-
-export const fakeRawRequests: RawRequestModel[] = [
+export const fakeRequests: RequestModel[] = [
   {
     id: 1,
     requesterEmail: fakeUser.email,
@@ -91,7 +85,10 @@ export const fakeRawRequests: RawRequestModel[] = [
     groupModel: fakeGroups[0],
     status: "PendingApproval",
     cluster: "caesfarm",
-    data: '{ "supervisingPI": "Dr. Bob Dobalina", "accessTypes": ["SshKey"] }',
+    data: {
+      supervisingPI: "Dr. Bob Dobalina",
+      accessTypes: ["SshKey"],
+    } as AccountRequestDataModel,
   },
   {
     id: 2,
@@ -101,11 +98,12 @@ export const fakeRawRequests: RawRequestModel[] = [
     groupModel: fakeGroups[1],
     status: "PendingApproval",
     cluster: "caesfarm",
-    data: '{ "supervisingPI": "Dr. Bob Dobalina", "accessTypes": ["SshKey"] }',
+    data: {
+      supervisingPI: "Dr. Bob Dobalina",
+      accessTypes: ["SshKey"],
+    } as AccountRequestDataModel,
   },
 ];
-
-export const fakeRequests = fakeRawRequests.map((r) => parseRawRequestModel(r));
 
 const fakeCluster: ClusterModel = {
   id: 1,

--- a/Hippo.Web/ClientApp/src/types.ts
+++ b/Hippo.Web/ClientApp/src/types.ts
@@ -18,30 +18,22 @@ export interface GroupAccountModel {
   email: string;
 }
 
-export interface RawGroupModel {
+export interface GroupModel {
   id: number;
   name: string;
   displayName: string;
   admins: GroupAccountModel[];
-  data: string;
+  data: PuppetGroupRecord;
 }
 
-export type GroupModel = Omit<RawGroupModel, "data"> & {
-  data: PuppetGroupRecord;
-};
-
-export interface RawRequestModel {
+export interface RequestModelCommon {
   id: number;
   requesterEmail: string;
   requesterName: string;
   groupModel: GroupModel;
   status: "PendingApproval" | "Rejected" | "Processing" | "Completed";
   cluster: string;
-  action: string;
-  data: string;
 }
-
-type RequestModelCommon = Omit<RawRequestModel, "action" | "data">;
 
 // action-specific RequestModel fields defined here...
 export interface AccountRequestDataModel {
@@ -57,7 +49,7 @@ export type AccountRequestModel = RequestModelCommon & {
 // make RequestMode a union of all possible action-specific RequestModels (currently only one)
 export type RequestModel = AccountRequestModel;
 
-export interface RawAccountModel {
+export interface AccountModel {
   id: number;
   name: string;
   email: string;
@@ -69,12 +61,8 @@ export interface RawAccountModel {
   adminOfGroups: GroupModel[];
   updatedOn: string;
   accessTypes: AccessType[];
-  data: string;
-}
-
-export type AccountModel = Omit<RawAccountModel, "data"> & {
   data: PuppetUserRecord;
-};
+}
 
 export interface AccountCreateModel {
   groupId: number;

--- a/Hippo.Web/ClientApp/src/util/api.ts
+++ b/Hippo.Web/ClientApp/src/util/api.ts
@@ -1,13 +1,4 @@
-import {
-  AccountModel,
-  AppContextShape,
-  GroupModel,
-  ModelState,
-  RawAccountModel,
-  RawGroupModel,
-  RawRequestModel,
-  RequestModel,
-} from "../types";
+import { AppContextShape, ModelState } from "../types";
 
 declare var Hippo: AppContextShape;
 
@@ -48,55 +39,4 @@ export const tryParseJSONObject = (val: string) => {
   } catch (e) {}
 
   return undefined;
-};
-
-export const parseRawRequestModel = (rawRequest: RawRequestModel) => {
-  try {
-    return {
-      ...rawRequest,
-      data: rawRequest.data && JSON.parse(rawRequest.data),
-    } as RequestModel;
-  } catch (error) {
-    console.log(error);
-    return {
-      ...rawRequest,
-      data: undefined,
-    } as RequestModel;
-  }
-};
-
-export const parseRawGroupModel = (rawGroup: RawGroupModel) => {
-  try {
-    return {
-      ...rawGroup,
-      data: rawGroup.data && JSON.parse(rawGroup.data),
-    } as GroupModel;
-  } catch (error) {
-    console.log(error);
-    return {
-      ...rawGroup,
-      data: undefined,
-    } as GroupModel;
-  }
-};
-
-export const parseRawAccountModel = (rawAccount: RawAccountModel) => {
-  try {
-    return {
-      ...rawAccount,
-      data: rawAccount.data && JSON.parse(rawAccount.data),
-      memberOfGroups: (
-        rawAccount.memberOfGroups as unknown as RawGroupModel[]
-      ).map(parseRawGroupModel),
-      adminOfGroups: (
-        rawAccount.adminOfGroups as unknown as RawGroupModel[]
-      ).map(parseRawGroupModel),
-    } as AccountModel;
-  } catch (error) {
-    console.log(error);
-    return {
-      ...rawAccount,
-      data: undefined,
-    } as AccountModel;
-  }
 };

--- a/Hippo.Web/Controllers/EventQueueController.cs
+++ b/Hippo.Web/Controllers/EventQueueController.cs
@@ -43,7 +43,7 @@ public class EventQueueController : Controller
                 Id = ae.Id,
                 Action = ae.Action,
                 Status = ae.Status,
-                Data = JsonSerializer.Deserialize<QueuedEventDataModel>(ae.Data, new JsonSerializerOptions { PropertyNameCaseInsensitive = true }),
+                Data = ae.Data,
                 CreatedAt = ae.CreatedAt,
                 UpdatedAt = ae.UpdatedAt
             })

--- a/Hippo.Web/Models/AccountModel.cs
+++ b/Hippo.Web/Models/AccountModel.cs
@@ -1,4 +1,5 @@
 using System.Linq.Expressions;
+using System.Text.Json;
 using Hippo.Core.Domain;
 using Hippo.Core.Models;
 
@@ -17,7 +18,7 @@ namespace Hippo.Web.Models
         public List<GroupModel> AdminOfGroups { get; set; } = new();
         public List<string> AccessTypes { get; set; } = new();
         public DateTime UpdatedOn { get; set; }
-        public string Data { get; set; } = "";
+        public JsonElement? Data { get; set; }
 
         public AccountModel()
         {

--- a/Hippo.Web/Views/Shared/_Layout.cshtml
+++ b/Hippo.Web/Views/Shared/_Layout.cshtml
@@ -53,12 +53,7 @@
 
         Hippo.user.detail = @Html.Raw(await UserService.GetCurrentUserJsonAsync());
         Hippo.user.permissions = @Html.Raw(await UserService.GetCurrentPermissionsJsonAsync());
-        Hippo.accounts = (@Html.Raw(await UserService.GetCurrentAccountsJsonAsync())).map(a => ({
-          ...a,
-          @* ensure data property of each group is deserialized *@
-          memberOfGroups: a.memberOfGroups.map(mg => ({ ...mg, data: ag.data ? JSON.parse(ag.data) : ag.data})),
-          adminOfGroups: a.adminOfGroups.map(ag => ({ ...ag, data: ag.data ? JSON.parse(ag.data) : ag.data})),
-        }));
+        Hippo.accounts = (@Html.Raw(await UserService.GetCurrentAccountsJsonAsync()));
         Hippo.openRequests = @Html.Raw(await UserService.GetCurrentOpenRequestsAsync());
         Hippo.clusters = @Html.Raw(await UserService.GetAvailableClustersJsonAsync());
         Hippo.antiForgeryToken = "@Xsrf.GetAndStoreTokens(Context).RequestToken";


### PR DESCRIPTION
Some of the json Data columns were being passed to the client as strings because only the client is concerned with their contents, and because the data makes extensive use of unions, which aren't easily represented with C# types. But deserializing the Data properties client-side was ugly and error-prone. Making the Data type `JsonElement` seemed like a nice compromise, they're still loosely typed server-side, but no need to parse them client-side.

I temporarily generated a new migration to verify that the ValueConverter didn't change anything in the schema or the model snapshot. Also verified that it didn't impact the bulk operations performed by the `AccountSyncService`.