### PR TITLE
useWatch instead of manually handling change

### DIFF
--- a/Hippo.Web/ClientApp/src/Shared/Form/FormField.tsx
+++ b/Hippo.Web/ClientApp/src/Shared/Form/FormField.tsx
@@ -19,6 +19,7 @@ const FormField = <T extends Record<string, any>>({
   readOnly = false,
   autoComplete,
   children,
+  disabled, // select out disabled and don't pass it to register or it will set the value to undefined
   ...options
 }: FormFieldProps<T>) => {
   const { ref, ...rest } = register(name, {
@@ -56,6 +57,7 @@ const FormField = <T extends Record<string, any>>({
           type={type}
           invalid={!!error}
           readOnly={readOnly}
+          disabled={disabled}
           autoComplete={autoComplete ?? "new-password"}
           {...rest}
         >

--- a/Hippo.Web/ClientApp/src/components/Order/Details.tsx
+++ b/Hippo.Web/ClientApp/src/components/Order/Details.tsx
@@ -76,20 +76,6 @@ export const Details = () => {
     [],
   );
 
-  const metadataColumns = useMemo<Column<OrderMetadataModel>[]>(
-    () => [
-      {
-        Header: "Name",
-        accessor: "name",
-      },
-      {
-        Header: "Value",
-        accessor: "value",
-      },
-    ],
-    [],
-  );
-
   const paymentColumns = useMemo<Column<PaymentModel>[]>(
     () => [
       {
@@ -203,8 +189,6 @@ export const Details = () => {
               ))}
             </tbody>
           </table>
-          <h2>Metadata</h2>
-          <ReactTable columns={metadataColumns} data={order.metaData} />
           <h2>History</h2>
           <ReactTable
             columns={historyColumns}

--- a/Hippo.Web/ClientApp/src/components/Order/MetaDataFields.tsx
+++ b/Hippo.Web/ClientApp/src/components/Order/MetaDataFields.tsx
@@ -32,6 +32,10 @@ const MetaDataFields: React.FC<MetaDataFieldsProps> = ({ readOnly }) => {
     remove(index);
   };
 
+  if (readOnly && fields.length === 0) {
+    return null;
+  }
+
   return (
     <>
       <h2>Metadata</h2>

--- a/Hippo.Web/ClientApp/src/components/Order/OrderForm.tsx
+++ b/Hippo.Web/ClientApp/src/components/Order/OrderForm.tsx
@@ -99,7 +99,7 @@ const OrderForm: React.FC<OrderFormProps> = ({
           readOnly={readOnly || !isAdmin}
           disabled={!readOnly && !isAdmin}
           inputPrepend={<FontAwesomeIcon icon={faDollarSign} />}
-          type={"number"}
+          valueAsNumber={true}
           deps={"total"}
         />
         <OrderFormField
@@ -140,7 +140,7 @@ const OrderForm: React.FC<OrderFormProps> = ({
           required={true}
           readOnly={readOnly}
           min={0.000001}
-          type="number"
+          valueAsNumber={true}
           deps={"total"}
         />
 
@@ -157,7 +157,7 @@ const OrderForm: React.FC<OrderFormProps> = ({
           readOnly={readOnly || !isAdmin}
           disabled={!readOnly && !isAdmin}
           inputPrepend={<FontAwesomeIcon icon={faDollarSign} />}
-          type="number"
+          valueAsNumber={true}
           deps={"total"}
         />
         <OrderFormField

--- a/Hippo.Web/ClientApp/src/components/Order/OrderForm.tsx
+++ b/Hippo.Web/ClientApp/src/components/Order/OrderForm.tsx
@@ -1,12 +1,13 @@
 import React from "react";
-import { FormProvider, set, useForm } from "react-hook-form";
-import { OrderModel, OrderTotalCalculationModel } from "../../types";
+import { FormProvider, useForm } from "react-hook-form";
+import { OrderModel } from "../../types";
 import { Form } from "reactstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faDollarSign } from "@fortawesome/free-solid-svg-icons";
 import FormSubmitButton from "../../Shared/Form/FormSubmitButton";
 import MetaDataFields from "./MetaDataFields";
 import OrderFormField from "./OrderFormField";
+import OrderFormTotalFields from "./OrderFormTotalFields";
 
 interface OrderFormProps {
   orderProp: OrderModel;
@@ -21,13 +22,13 @@ const OrderForm: React.FC<OrderFormProps> = ({
   isAdmin,
   onSubmit,
 }) => {
-  const methods = useForm<OrderModel>({ defaultValues: orderProp });
+  const methods = useForm<OrderModel>({
+    defaultValues: orderProp,
+    mode: "onBlur",
+  });
   const {
     handleSubmit,
     setError,
-    getValues,
-    setValue,
-    clearErrors,
     formState: { isDirty, isSubmitting },
   } = methods;
 
@@ -48,116 +49,75 @@ const OrderForm: React.FC<OrderFormProps> = ({
     }
   };
 
-  const updateTotals = (
-    field: keyof OrderTotalCalculationModel,
-    value: number,
-  ) => {
-    const data = getValues();
-    console.log(data);
-
-    let adjustment = 0.0;
-    try {
-      adjustment =
-        field === "adjustment" ? value : parseFloat(data.adjustment.toString()); // Don't know why, but depending on the order of values changed, this can show up as a string
-    } catch (error) {
-      adjustment = 0.0;
-    }
-    const quantity = field === "quantity" ? value : data.quantity;
-    const unitPrice =
-      field === "unitPrice" ? value : parseFloat(data.unitPrice);
-
-    const subTotal = quantity * unitPrice;
-    const total = subTotal + adjustment;
-    //const balanceRemaining = total;
-    //Possibly show a Installment payment amount
-
-    try {
-      setValue("subTotal", subTotal.toFixed(2));
-    } catch (error) {
-      setValue("subTotal", "0");
-    }
-
-    try {
-      setValue("total", total.toFixed(2));
-    } catch (error) {
-      setValue("total", "0");
-    }
-    clearErrors("total");
-    if (total < 0) {
-      setError("total", {
-        type: "custom",
-        message: "Total must be a positive number",
-      });
-    }
-  };
-
   // TODO: rest of input validation?
   return (
     <FormProvider {...methods}>
       <Form onSubmit={handleSubmit(submitForm)} className="mb-3">
-        <fieldset disabled>
-          <OrderFormField
-            name="status"
-            label="Status"
-            required={false}
-            readOnly={true}
-          />
-        </fieldset>
+        <OrderFormField
+          name="status"
+          label="Status"
+          required={false}
+          readOnly={true}
+          disabled={true}
+        />
         <hr />
-        <fieldset disabled={!readOnly && !isAdmin}>
-          <OrderFormField
-            name="productName"
-            label="Product Name"
-            required={true}
-            readOnly={readOnly || !isAdmin}
-            maxLength={50}
-          />
-          <OrderFormField
-            name="description"
-            label="Description"
-            type="textarea"
-            required={true}
-            readOnly={readOnly || !isAdmin}
-            maxLength={250}
-          />
-          <OrderFormField
-            name="category"
-            label="Category"
-            readOnly={readOnly || !isAdmin}
-          />
-          <OrderFormField
-            name="units"
-            label="Units"
-            required={true}
-            readOnly={readOnly || !isAdmin}
-          />
+        <OrderFormField
+          name="productName"
+          label="Product Name"
+          required={true}
+          readOnly={readOnly || !isAdmin}
+          disabled={!readOnly && !isAdmin}
+          maxLength={50}
+        />
+        <OrderFormField
+          name="description"
+          label="Description"
+          type="textarea"
+          required={true}
+          readOnly={readOnly || !isAdmin}
+          disabled={!readOnly && !isAdmin}
+          maxLength={250}
+        />
+        <OrderFormField
+          name="category"
+          label="Category"
+          readOnly={readOnly || !isAdmin}
+          disabled={!readOnly && !isAdmin}
+        />
+        <OrderFormField
+          name="units"
+          label="Units"
+          required={true}
+          readOnly={readOnly || !isAdmin}
+          disabled={!readOnly && !isAdmin}
+        />
 
-          <OrderFormField
-            name="unitPrice"
-            label="Unit Price"
-            required={true}
-            readOnly={readOnly || !isAdmin}
-            onChange={(e) =>
-              updateTotals("unitPrice", parseFloat(e.target.value))
-            }
-            inputPrepend={<FontAwesomeIcon icon={faDollarSign} />}
-          />
-          <OrderFormField
-            name="installments"
-            label="Installments"
-            readOnly={readOnly || !isAdmin}
-          />
-          <OrderFormField
-            name="installmentType"
-            label="Installment Type"
-            readOnly={readOnly || !isAdmin}
-            disabled={readOnly || !isAdmin}
-            type="select"
-          >
-            <option value="Monthly">Monthly</option>
-            <option value="Yearly">Yearly</option>
-          </OrderFormField>
-        </fieldset>
+        <OrderFormField
+          name="unitPrice"
+          label="Unit Price"
+          required={true}
+          readOnly={readOnly || !isAdmin}
+          disabled={!readOnly && !isAdmin}
+          inputPrepend={<FontAwesomeIcon icon={faDollarSign} />}
+          type={"number"}
+          deps={"total"}
+        />
+        <OrderFormField
+          name="installments"
+          label="Installments"
+          readOnly={readOnly || !isAdmin}
+          disabled={!readOnly && !isAdmin}
+        />
+        <OrderFormField
+          name="installmentType"
+          label="Installment Type"
+          readOnly={readOnly || !isAdmin}
+          disabled={!readOnly && !isAdmin}
+          type="select"
+        >
+          <option value="Monthly">Monthly</option>
+          <option value="Yearly">Yearly</option>
+        </OrderFormField>
         <OrderFormField
           name="name"
           label="Name"
@@ -180,31 +140,34 @@ const OrderForm: React.FC<OrderFormProps> = ({
           required={true}
           readOnly={readOnly}
           min={0.000001}
-          onChange={(e) => updateTotals("quantity", parseFloat(e.target.value))}
+          type="number"
+          deps={"total"}
         />
-        <fieldset disabled={!readOnly && !isAdmin}>
-          <OrderFormField
-            name="externalReference"
-            label="External Reference"
-            readOnly={readOnly || !isAdmin}
-            maxLength={150}
-          />
-          <OrderFormField
-            name="adjustment"
-            label="Adjustment"
-            readOnly={readOnly || !isAdmin}
-            onChange={(e) =>
-              updateTotals("adjustment", parseFloat(e.target.value))
-            }
-            inputPrepend={<FontAwesomeIcon icon={faDollarSign} />}
-          />
-          <OrderFormField
-            name="adjustmentReason"
-            label="Adjustment Reason"
-            readOnly={readOnly || !isAdmin}
-            type="textarea"
-          />
-        </fieldset>
+
+        <OrderFormField
+          name="externalReference"
+          label="External Reference"
+          readOnly={readOnly || !isAdmin}
+          disabled={!readOnly && !isAdmin}
+          maxLength={150}
+        />
+        <OrderFormField
+          name="adjustment"
+          label="Adjustment"
+          readOnly={readOnly || !isAdmin}
+          disabled={!readOnly && !isAdmin}
+          inputPrepend={<FontAwesomeIcon icon={faDollarSign} />}
+          type="number"
+          deps={"total"}
+        />
+        <OrderFormField
+          name="adjustmentReason"
+          label="Adjustment Reason"
+          readOnly={readOnly || !isAdmin}
+          disabled={!readOnly && !isAdmin}
+          type="textarea"
+        />
+
         {isAdmin && (
           <OrderFormField
             name="adminNotes"
@@ -215,20 +178,8 @@ const OrderForm: React.FC<OrderFormProps> = ({
         )}
         <MetaDataFields readOnly={readOnly} />
         <hr />
-        <OrderFormField
-          name="subTotal"
-          label="SubTotal"
-          readOnly={true}
-          disabled={true}
-          inputPrepend={<FontAwesomeIcon icon={faDollarSign} />}
-        />
-        <OrderFormField
-          name="total"
-          label="Total"
-          readOnly={true}
-          disabled={true}
-          inputPrepend={<FontAwesomeIcon icon={faDollarSign} />}
-        />
+
+        <OrderFormTotalFields />
 
         {!readOnly && <FormSubmitButton className="mb-3 mt-3" />}
       </Form>

--- a/Hippo.Web/ClientApp/src/components/Order/OrderFormTotalFields.tsx
+++ b/Hippo.Web/ClientApp/src/components/Order/OrderFormTotalFields.tsx
@@ -27,8 +27,8 @@ const OrderFormTotalFields: React.FC<OrderFormTotalFieldsProps> = () => {
   const subTotal = quantity * parseFloat(unitPrice);
   const total = subTotal + Number(adjustment);
 
-  setValue("subTotal", subTotal.toString());
-  setValue("total", total.toString());
+  setValue("subTotal", subTotal.toFixed(2));
+  setValue("total", total.toFixed(2));
 
   return (
     <>
@@ -44,7 +44,7 @@ const OrderFormTotalFields: React.FC<OrderFormTotalFieldsProps> = () => {
         type="number"
         name="total"
         label="Total"
-        min={0}
+        min={0.01}
         readOnly={true}
         disabled={true}
         inputPrepend={<FontAwesomeIcon icon={faDollarSign} />}

--- a/Hippo.Web/ClientApp/src/components/Order/OrderFormTotalFields.tsx
+++ b/Hippo.Web/ClientApp/src/components/Order/OrderFormTotalFields.tsx
@@ -1,0 +1,56 @@
+import { OrderModel } from "../../types";
+import { useFormContext, useWatch } from "react-hook-form";
+import { faDollarSign } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import OrderFormField from "./OrderFormField";
+
+type OrderFormTotalFieldsProps = {};
+
+const OrderFormTotalFields: React.FC<OrderFormTotalFieldsProps> = () => {
+  const { setValue } = useFormContext<OrderModel>();
+
+  // watch these values and recalculate when they change
+  // to have changes trigger validation for the total field,
+  // add it as a dep prop for quanitity, unitPrice, and adjustment fields
+  const quantity = useWatch({
+    name: "quantity",
+  });
+
+  const unitPrice = useWatch({
+    name: "unitPrice",
+  });
+
+  const adjustment = useWatch({
+    name: "adjustment",
+  });
+
+  const subTotal = quantity * parseFloat(unitPrice);
+  const total = subTotal + Number(adjustment);
+
+  setValue("subTotal", subTotal.toString());
+  setValue("total", total.toString());
+
+  return (
+    <>
+      <OrderFormField
+        name="subTotal"
+        label="SubTotal"
+        readOnly={true}
+        disabled={true}
+        inputPrepend={<FontAwesomeIcon icon={faDollarSign} />}
+        type="number"
+      />
+      <OrderFormField
+        type="number"
+        name="total"
+        label="Total"
+        min={0}
+        readOnly={true}
+        disabled={true}
+        inputPrepend={<FontAwesomeIcon icon={faDollarSign} />}
+      />
+    </>
+  );
+};
+
+export default OrderFormTotalFields;


### PR DESCRIPTION
useWatch() instead of handling the change ourselves. moved it into its own component, which will only rerender when the watched values change. now we don't have to do anything special to validate the total, just `min`, but to trigger the validation you have to add `deps="total"` to the fields it relies on. 

i stopped passing disabled into the `register()` because it sets the value to undefined and was causing weird issues, now the disabled prop only gets passed directly to the input 