### PR TITLE
Refactor account sync (merge all clusters at once)

### DIFF
--- a/Hippo.Core/Data/AppDbContext.cs
+++ b/Hippo.Core/Data/AppDbContext.cs
@@ -57,6 +57,8 @@ namespace Hippo.Core.Data
             Domain.GroupMemberAccount.OnModelCreating(builder);
             QueuedEvent.OnModelCreating(builder, this);
             AccessType.OnModelCreating(builder);
+            TempGroup.OnModelCreating(builder);
+            Domain.TempKerberos.OnModelCreating(builder);
         }
     }
- }
+}

--- a/Hippo.Core/Domain/History.cs
+++ b/Hippo.Core/Domain/History.cs
@@ -29,7 +29,7 @@ namespace Hippo.Core.Domain
 
         public string Details { get; set; } = String.Empty;
 
-        public int ClusterId { get; set; } //When we have a cluster identifier 
+        public int? ClusterId { get; set; } //When we have a cluster identifier 
         public Cluster Cluster { get; set; }
 
         [MaxLength(50)]

--- a/Hippo.Core/Domain/TempGroup.cs
+++ b/Hippo.Core/Domain/TempGroup.cs
@@ -5,7 +5,12 @@ namespace Hippo.Core.Domain
 {
     public class TempGroup
     {
-        [Key]
+        public int ClusterId { get; set; }
         public string Group { get; set; } = "";
+
+        internal static void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<TempGroup>().HasKey(a => new { a.ClusterId, a.Group });
+        }
     }
 }

--- a/Hippo.Core/Domain/TempKerberos.cs
+++ b/Hippo.Core/Domain/TempKerberos.cs
@@ -5,7 +5,12 @@ namespace Hippo.Core.Domain
 {
     public class TempKerberos
     {
-        [Key]
+        public int ClusterId { get; set; }
         public string Kerberos { get; set; } = "";
+
+        internal static void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<TempKerberos>().HasKey(a => new { a.ClusterId, a.Kerberos });
+        }
     }
 }

--- a/Hippo.Core/Migrations/SqlServer/20240711203741_RefactorAccountSync.Designer.cs
+++ b/Hippo.Core/Migrations/SqlServer/20240711203741_RefactorAccountSync.Designer.cs
@@ -4,6 +4,7 @@ using Hippo.Core.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Hippo.Core.Migrations.SqlServer
 {
     [DbContext(typeof(AppDbContextSqlServer))]
-    partial class AppDbContextSqlServerModelSnapshot : ModelSnapshot
+    [Migration("20240711203741_RefactorAccountSync")]
+    partial class RefactorAccountSync
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Hippo.Core/Migrations/SqlServer/20240711203741_RefactorAccountSync.cs
+++ b/Hippo.Core/Migrations/SqlServer/20240711203741_RefactorAccountSync.cs
@@ -1,0 +1,93 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Hippo.Core.Migrations.SqlServer
+{
+    public partial class RefactorAccountSync : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_TempKerberos",
+                table: "TempKerberos");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_TempGroups",
+                table: "TempGroups");
+
+            migrationBuilder.AddColumn<int>(
+                name: "ClusterId",
+                table: "TempKerberos",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "ClusterId",
+                table: "TempGroups",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "ClusterId",
+                table: "Histories",
+                type: "int",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "int");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_TempKerberos",
+                table: "TempKerberos",
+                columns: new[] { "ClusterId", "Kerberos" });
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_TempGroups",
+                table: "TempGroups",
+                columns: new[] { "ClusterId", "Group" });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_TempKerberos",
+                table: "TempKerberos");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_TempGroups",
+                table: "TempGroups");
+
+            migrationBuilder.DropColumn(
+                name: "ClusterId",
+                table: "TempKerberos");
+
+            migrationBuilder.DropColumn(
+                name: "ClusterId",
+                table: "TempGroups");
+
+            migrationBuilder.Sql("DELETE FROM Histories WHERE ClusterId IS NULL;");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "ClusterId",
+                table: "Histories",
+                type: "int",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "int",
+                oldNullable: true);
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_TempKerberos",
+                table: "TempKerberos",
+                column: "Kerberos");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_TempGroups",
+                table: "TempGroups",
+                column: "Group");
+        }
+    }
+}

--- a/Hippo.Core/Migrations/Sqlite/20240711203730_RefactorAccountSync.Designer.cs
+++ b/Hippo.Core/Migrations/Sqlite/20240711203730_RefactorAccountSync.Designer.cs
@@ -3,32 +3,29 @@ using System;
 using Hippo.Core.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace Hippo.Core.Migrations.SqlServer
+namespace Hippo.Core.Migrations.Sqlite
 {
-    [DbContext(typeof(AppDbContextSqlServer))]
-    partial class AppDbContextSqlServerModelSnapshot : ModelSnapshot
+    [DbContext(typeof(AppDbContextSqlite))]
+    [Migration("20240711203730_RefactorAccountSync")]
+    partial class RefactorAccountSync
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder
-                .HasAnnotation("ProductVersion", "6.0.19")
-                .HasAnnotation("Relational:MaxIdentifierLength", 128);
-
-            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder, 1L, 1);
+            modelBuilder.HasAnnotation("ProductVersion", "6.0.19");
 
             modelBuilder.Entity("AccessTypeAccount", b =>
                 {
                     b.Property<int>("AccessTypesId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("AccountsId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("AccessTypesId", "AccountsId");
 
@@ -40,10 +37,10 @@ namespace Hippo.Core.Migrations.SqlServer
             modelBuilder.Entity("AccessTypeCluster", b =>
                 {
                     b.Property<int>("AccessTypesId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("ClustersId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("AccessTypesId", "ClustersId");
 
@@ -56,14 +53,12 @@ namespace Hippo.Core.Migrations.SqlServer
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"), 1L, 1);
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -77,39 +72,37 @@ namespace Hippo.Core.Migrations.SqlServer
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"), 1L, 1);
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("ClusterId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Data")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Email")
                         .HasMaxLength(300)
-                        .HasColumnType("nvarchar(300)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Kerberos")
                         .HasMaxLength(20)
-                        .HasColumnType("nvarchar(20)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Name")
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("OwnerId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("SshKey")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("UpdatedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -134,44 +127,42 @@ namespace Hippo.Core.Migrations.SqlServer
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"), 1L, 1);
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Description")
                         .IsRequired()
                         .HasMaxLength(250)
-                        .HasColumnType("nvarchar(250)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Domain")
                         .HasMaxLength(250)
-                        .HasColumnType("nvarchar(250)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Email")
                         .HasMaxLength(250)
-                        .HasColumnType("nvarchar(250)");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("IsActive")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("bit")
+                        .HasColumnType("INTEGER")
                         .HasDefaultValue(true);
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(20)
-                        .HasColumnType("nvarchar(20)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("SshKeyId")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("SshName")
                         .HasMaxLength(250)
-                        .HasColumnType("nvarchar(250)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("SshUrl")
                         .HasMaxLength(250)
-                        .HasColumnType("nvarchar(250)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -184,24 +175,22 @@ namespace Hippo.Core.Migrations.SqlServer
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"), 1L, 1);
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("ClusterId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Data")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("DisplayName")
                         .HasMaxLength(250)
-                        .HasColumnType("nvarchar(250)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(32)
-                        .HasColumnType("nvarchar(32)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -214,10 +203,10 @@ namespace Hippo.Core.Migrations.SqlServer
             modelBuilder.Entity("Hippo.Core.Domain.GroupAdminAccount", b =>
                 {
                     b.Property<int>("AccountId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("GroupId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("AccountId", "GroupId");
 
@@ -229,10 +218,10 @@ namespace Hippo.Core.Migrations.SqlServer
             modelBuilder.Entity("Hippo.Core.Domain.GroupMemberAccount", b =>
                 {
                     b.Property<int>("AccountId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("GroupId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("AccountId", "GroupId");
 
@@ -245,32 +234,30 @@ namespace Hippo.Core.Migrations.SqlServer
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"), 1L, 1);
+                        .HasColumnType("INTEGER");
 
                     b.Property<int?>("ActedById")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("ActedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Action")
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("AdminAction")
-                        .HasColumnType("bit");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int?>("ClusterId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Details")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Status")
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -289,18 +276,16 @@ namespace Hippo.Core.Migrations.SqlServer
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"), 1L, 1);
+                        .HasColumnType("INTEGER");
 
                     b.Property<int?>("ClusterId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("RoleId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("UserId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("Id");
 
@@ -317,32 +302,30 @@ namespace Hippo.Core.Migrations.SqlServer
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"), 1L, 1);
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Action")
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Data")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ErrorMessage")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("RequestId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Status")
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("UpdatedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -363,48 +346,46 @@ namespace Hippo.Core.Migrations.SqlServer
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"), 1L, 1);
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Action")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("ActorId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("ClusterId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Data")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Group")
                         .HasMaxLength(32)
-                        .HasColumnType("nvarchar(32)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("RequesterId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("SshKey")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Status")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("SupervisingPI")
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("UpdatedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -427,14 +408,12 @@ namespace Hippo.Core.Migrations.SqlServer
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"), 1L, 1);
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -447,10 +426,10 @@ namespace Hippo.Core.Migrations.SqlServer
             modelBuilder.Entity("Hippo.Core.Domain.TempGroup", b =>
                 {
                     b.Property<int>("ClusterId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Group")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("ClusterId", "Group");
 
@@ -460,10 +439,10 @@ namespace Hippo.Core.Migrations.SqlServer
             modelBuilder.Entity("Hippo.Core.Domain.TempKerberos", b =>
                 {
                     b.Property<int>("ClusterId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Kerberos")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("ClusterId", "Kerberos");
 
@@ -474,44 +453,41 @@ namespace Hippo.Core.Migrations.SqlServer
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"), 1L, 1);
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Email")
                         .IsRequired()
                         .HasMaxLength(300)
-                        .HasColumnType("nvarchar(300)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("FirstName")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Iam")
                         .HasMaxLength(10)
-                        .HasColumnType("nvarchar(10)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Kerberos")
                         .HasMaxLength(20)
-                        .HasColumnType("nvarchar(20)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("LastName")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("MothraId")
                         .HasMaxLength(20)
-                        .HasColumnType("nvarchar(20)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
                     b.HasIndex("Email");
 
                     b.HasIndex("Iam")
-                        .IsUnique()
-                        .HasFilter("[Iam] IS NOT NULL");
+                        .IsUnique();
 
                     b.ToTable("Users");
                 });

--- a/Hippo.Core/Migrations/Sqlite/20240711203730_RefactorAccountSync.cs
+++ b/Hippo.Core/Migrations/Sqlite/20240711203730_RefactorAccountSync.cs
@@ -1,0 +1,93 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Hippo.Core.Migrations.Sqlite
+{
+    public partial class RefactorAccountSync : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_TempKerberos",
+                table: "TempKerberos");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_TempGroups",
+                table: "TempGroups");
+
+            migrationBuilder.AddColumn<int>(
+                name: "ClusterId",
+                table: "TempKerberos",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "ClusterId",
+                table: "TempGroups",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "ClusterId",
+                table: "Histories",
+                type: "INTEGER",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "INTEGER");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_TempKerberos",
+                table: "TempKerberos",
+                columns: new[] { "ClusterId", "Kerberos" });
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_TempGroups",
+                table: "TempGroups",
+                columns: new[] { "ClusterId", "Group" });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_TempKerberos",
+                table: "TempKerberos");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_TempGroups",
+                table: "TempGroups");
+
+            migrationBuilder.DropColumn(
+                name: "ClusterId",
+                table: "TempKerberos");
+
+            migrationBuilder.DropColumn(
+                name: "ClusterId",
+                table: "TempGroups");
+
+            migrationBuilder.Sql("DELETE FROM Histories WHERE ClusterId IS NULL;");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "ClusterId",
+                table: "Histories",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "INTEGER",
+                oldNullable: true);
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_TempKerberos",
+                table: "TempKerberos",
+                column: "Kerberos");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_TempGroups",
+                table: "TempGroups",
+                column: "Group");
+        }
+    }
+}

--- a/Hippo.Core/Migrations/Sqlite/AppDbContextSqliteModelSnapshot.cs
+++ b/Hippo.Core/Migrations/Sqlite/AppDbContextSqliteModelSnapshot.cs
@@ -247,7 +247,7 @@ namespace Hippo.Core.Migrations.Sqlite
                     b.Property<bool>("AdminAction")
                         .HasColumnType("INTEGER");
 
-                    b.Property<int>("ClusterId")
+                    b.Property<int?>("ClusterId")
                         .HasColumnType("INTEGER");
 
                     b.Property<string>("Details")
@@ -423,20 +423,26 @@ namespace Hippo.Core.Migrations.Sqlite
 
             modelBuilder.Entity("Hippo.Core.Domain.TempGroup", b =>
                 {
+                    b.Property<int>("ClusterId")
+                        .HasColumnType("INTEGER");
+
                     b.Property<string>("Group")
                         .HasColumnType("TEXT");
 
-                    b.HasKey("Group");
+                    b.HasKey("ClusterId", "Group");
 
                     b.ToTable("TempGroups");
                 });
 
             modelBuilder.Entity("Hippo.Core.Domain.TempKerberos", b =>
                 {
+                    b.Property<int>("ClusterId")
+                        .HasColumnType("INTEGER");
+
                     b.Property<string>("Kerberos")
                         .HasColumnType("TEXT");
 
-                    b.HasKey("Kerberos");
+                    b.HasKey("ClusterId", "Kerberos");
 
                     b.ToTable("TempKerberos");
                 });
@@ -591,8 +597,7 @@ namespace Hippo.Core.Migrations.Sqlite
                     b.HasOne("Hippo.Core.Domain.Cluster", "Cluster")
                         .WithMany()
                         .HasForeignKey("ClusterId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
+                        .OnDelete(DeleteBehavior.Restrict);
 
                     b.Navigation("ActedBy");
 

--- a/Hippo.Core/Services/HistoryService.cs
+++ b/Hippo.Core/Services/HistoryService.cs
@@ -196,12 +196,11 @@ namespace Hippo.Core.Services
             await historyService.AddHistory(history);
         }
 
-        public static async Task PuppetDataSynced(this IHistoryService historyService, int clusterId)
+        public static async Task PuppetDataSynced(this IHistoryService historyService)
         {
             var history = new History
             {
                 Action = Actions.PuppetDataSynced,
-                ClusterId = clusterId,
                 ActedDate = DateTime.UtcNow,
             };
             await historyService.AddHistory(history);


### PR DESCRIPTION
I verified that it is correctly removing group memberships.

I wasn't sure about using a tuple `(a.ClusterId, a.Kerberos)` as a dictionary key, but it seemed cleaner than defining a wrapper type and manually implementing all the hash/equality stuff to be able to use it as a key.