### PR TITLE
Leave sshkey out of yaml when disabled/not relevant

### DIFF
--- a/Hippo.Core/Services/AccountUpdateYamlService.cs
+++ b/Hippo.Core/Services/AccountUpdateYamlService.cs
@@ -47,23 +47,41 @@ public class AccountUpdateYamlService : IAccountUpdateService
         var group = queuedEventModel.Data.Groups.SingleOrDefault();
         var serializer = new Serializer();
         return serializer.Serialize(
-            new
-            {
-                groups = group != null ? new[] { group.Name } : new string[] { },
-                account = new
+            string.IsNullOrWhiteSpace(account.Key)
+                ? new
                 {
-                    name = account.Name,
-                    email = account.Email,
-                    kerb = account.Kerberos,
-                    iam = account.Iam,
-                    mothra = account.Mothra,
-                    key = account.Key
-                },
-                meta = new
-                {
-                    cluster = queuedEventModel.Data.Cluster
+                    groups = group != null ? new[] { group.Name } : new string[] { },
+                    account = new
+                    {
+                        name = account.Name,
+                        email = account.Email,
+                        kerb = account.Kerberos,
+                        iam = account.Iam,
+                        mothra = account.Mothra,
+                        // no key in this request, so excluding it from yaml
+                    },
+                    meta = new
+                    {
+                        cluster = queuedEventModel.Data.Cluster
+                    }
                 }
-            }
+                : new
+                {
+                    groups = group != null ? new[] { group.Name } : new string[] { },
+                    account = new
+                    {
+                        name = account.Name,
+                        email = account.Email,
+                        kerb = account.Kerberos,
+                        iam = account.Iam,
+                        mothra = account.Mothra,
+                        key = account.Key
+                    },
+                    meta = new
+                    {
+                        cluster = queuedEventModel.Data.Cluster
+                    }
+                }
         );
     }
 


### PR DESCRIPTION
Not sure if there's any way to really test this. It should be safe to rely on only the presence of `account.Key`, since that was thoroughly validated at the time an account was requested...

https://github.com/ucdavis/hippo/blob/05086736d396b85df548b9935ad0415031536ef0/Hippo.Web/Controllers/AccountController.cs#L108-L137

Closes #289 