### PR TITLE
Add group member removal feature

### DIFF
--- a/Hippo.Core/Domain/QueuedEvent.cs
+++ b/Hippo.Core/Domain/QueuedEvent.cs
@@ -39,11 +39,13 @@ public class QueuedEvent
         public const string UpdateSshKey = "UpdateSshKey";
         public const string AddAccountToGroup = "AddAccountToGroup";
         public const string CreateGroup = "CreateGroup";
+        public const string RemoveGroupMember = "RemoveGroupMember";
 
         public const string RegexPattern = CreateAccount
             + "|" + UpdateSshKey
             + "|" + AddAccountToGroup
-            + "|" + CreateGroup;
+            + "|" + CreateGroup
+            + "|" + RemoveGroupMember;
     }
 
     public static class Statuses

--- a/Hippo.Core/Models/QueuedEventModel.cs
+++ b/Hippo.Core/Models/QueuedEventModel.cs
@@ -127,11 +127,12 @@ public class QueuedEventAccountModel
     {
         return new QueuedEventAccountModel
         {
-            Kerberos = account.Owner.Kerberos,
+            Kerberos = account.Kerberos,
             Name = account.Name,
-            Email = account.Owner.Email,
-            Iam = account.Owner.Iam,
-            Mothra = account.Owner.MothraId,
+            Email = account.Email,
+            // accounts won't have an owner if they've never logged into hippo
+            Iam = account.Owner?.Iam ?? "",
+            Mothra = account.Owner?.MothraId ?? "",
             Key = account.SshKey,
             AccessTypes = account.AccessTypes.Select(at => at.Name).ToList()
         };

--- a/Hippo.Web/ClientApp/src/App.tsx
+++ b/Hippo.Web/ClientApp/src/App.tsx
@@ -34,6 +34,7 @@ import NotAuthorized from "./Shared/LoadingAndErrors/NotAuthorized";
 import { FinancialAdmins } from "./components/Admin/FinancialAdmins";
 import { Payments } from "./components/Report/Payments";
 import { ReportOrders } from "./components/Report/ReportOrders";
+import GroupMembers from "./components/Group/GroupMembers";
 
 declare var Hippo: AppContextShape;
 
@@ -268,6 +269,17 @@ const App = () => {
                   alternative={<NotAuthorized />}
                 >
                   <ReportOrders />
+                </ShowFor>
+              }
+            />
+            <Route
+              path="/:cluster/group/:groupId"
+              element={
+                <ShowFor
+                  roles={["System", "ClusterAdmin", "GroupAdmin"]}
+                  alternative={<NotAuthorized />}
+                >
+                  <GroupMembers />
                 </ShowFor>
               }
             />

--- a/Hippo.Web/ClientApp/src/Shared/usePermissions.ts
+++ b/Hippo.Web/ClientApp/src/Shared/usePermissions.ts
@@ -21,11 +21,20 @@ export const usePermissions = () => {
     return false;
   };
 
+  const canManageGroup = (groupName: string) => {
+    if (isSystemAdmin || isClusterAdmin) return true;
+    if (!clusterName) return false;
+    const account = accounts.find((a) => a.cluster === clusterName);
+    if (!account) return false;
+    if (account.adminOfGroups.some((g) => g.name === groupName)) return true;
+    return false;
+  };
+
   const isClusterAdminForCluster = () => {
     if (!clusterName) return false;
     if (isSystemAdmin || isClusterAdmin) return true;
     return false;
   };
 
-  return { canViewGroup, isClusterAdminForCluster };
+  return { canViewGroup, canManageGroup, isClusterAdminForCluster };
 };

--- a/Hippo.Web/ClientApp/src/components/Account/AccountInfo.tsx
+++ b/Hippo.Web/ClientApp/src/components/Account/AccountInfo.tsx
@@ -318,6 +318,10 @@ export const AccountInfo = () => {
     showGroupDetails();
   };
 
+  const handleNavigateToGroupMembers = (group: GroupModel) => {
+    navigate(`/${clusterName}/group/${group.id}`);
+  };
+
   return (
     <HipMainWrapper>
       <HipTitle title={`Welcome ${context.user.detail.firstName}`} />
@@ -342,7 +346,13 @@ export const AccountInfo = () => {
             <CardColumns>
               {adminOfGroups.map((g, i) => (
                 <div className="group-card-admin" key={i}>
-                  <GroupInfo group={g} showDetails={() => handleShowGroup(g)} />
+                  <GroupInfo
+                    group={g}
+                    showDetails={() => handleShowGroup(g)}
+                    navigateToGroupMembers={() =>
+                      handleNavigateToGroupMembers(g)
+                    }
+                  />
                 </div>
               ))}
             </CardColumns>

--- a/Hippo.Web/ClientApp/src/components/Account/ActiveAccounts.tsx
+++ b/Hippo.Web/ClientApp/src/components/Account/ActiveAccounts.tsx
@@ -17,7 +17,7 @@ import { HipTable } from "../../Shared/Table/HipTable";
 import HipButton from "../../Shared/HipComponents/HipButton";
 
 export const ActiveAccounts = () => {
-  const [notification, setNotification] = usePromiseNotification();
+  const [, setNotification] = usePromiseNotification();
   const [accounts, setAccounts] = useState<AccountModel[]>();
   const [viewing, setViewing] = useState<AccountModel>();
   const [editing, setEditing] = useState<AccountModel>();

--- a/Hippo.Web/ClientApp/src/components/Group/GroupInfo.tsx
+++ b/Hippo.Web/ClientApp/src/components/Group/GroupInfo.tsx
@@ -7,15 +7,26 @@ import { MouseEvent } from "react";
 export interface GroupInfoProps {
   group: GroupModel;
   showDetails?: () => void;
+  navigateToGroupMembers?: () => void;
 }
 
-export const GroupInfo = ({ group, showDetails }: GroupInfoProps) => {
-  const { canViewGroup } = usePermissions();
+export const GroupInfo = ({
+  group,
+  showDetails,
+  navigateToGroupMembers,
+}: GroupInfoProps) => {
+  const { canViewGroup, canManageGroup } = usePermissions();
 
   const handleShowDetails = async (e: MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
     e.preventDefault();
     showDetails();
+  };
+
+  const handleShowMembers = async (e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    e.preventDefault();
+    navigateToGroupMembers();
   };
 
   return (
@@ -39,6 +50,14 @@ export const GroupInfo = ({ group, showDetails }: GroupInfoProps) => {
       <ShowFor condition={() => !!showDetails && canViewGroup(group.name)}>
         <Button size="sm" color="link" onClick={handleShowDetails}>
           Details
+        </Button>
+      </ShowFor>
+      <ShowFor
+        condition={() => !!navigateToGroupMembers && canManageGroup(group.name)}
+      >
+        {" - "}
+        <Button size="sm" color="link" onClick={handleShowMembers}>
+          View Members
         </Button>
       </ShowFor>
     </div>

--- a/Hippo.Web/ClientApp/src/components/Group/GroupMembers.tsx
+++ b/Hippo.Web/ClientApp/src/components/Group/GroupMembers.tsx
@@ -1,0 +1,204 @@
+import React, { useEffect, useState } from "react";
+import ObjectTree from "../../Shared/ObjectTree";
+import { AccountModel, GroupMembersModel } from "../../types";
+import { useParams } from "react-router-dom";
+import NotFound from "../../NotFound";
+import { createColumnHelper } from "@tanstack/react-table";
+import HipButton from "../../Shared/HipComponents/HipButton";
+import HipBody from "../../Shared/Layout/HipBody";
+import HipMainWrapper from "../../Shared/Layout/HipMainWrapper";
+import HipTitle from "../../Shared/Layout/HipTitle";
+import HipLoading from "../../Shared/LoadingAndErrors/HipLoading";
+import { HipTable } from "../../Shared/Table/HipTable";
+import { authenticatedFetch, parseBadRequest } from "../../util/api";
+import { useConfirmationDialog } from "../../Shared/ConfirmationDialog";
+import { GroupInfo } from "./GroupInfo";
+import { usePromiseNotification } from "../../util/Notifications";
+
+const GroupMembers: React.FC = () => {
+  const { cluster: clusterName, groupId: groupIdStr } = useParams<{
+    cluster: string;
+    groupId: string;
+  }>();
+  const groupId = parseInt(groupIdStr);
+  const [removing, setRemoving] = useState<AccountModel>();
+  const [groupMembers, setGroupMembers] = useState<GroupMembersModel>();
+  const [, setNotification] = usePromiseNotification();
+
+  useEffect(() => {
+    const fetchAccounts = async () => {
+      const response = await authenticatedFetch(
+        `/api/${clusterName}/account/groupMembers?groupId=${groupId}`,
+      );
+
+      if (response.ok) {
+        setGroupMembers((await response.json()) as GroupMembersModel);
+      }
+    };
+
+    fetchAccounts();
+  }, [clusterName, groupId]);
+
+  const details = {
+    name: groupMembers?.group.name,
+    displayName: groupMembers?.group.displayName,
+    admins: (groupMembers?.group.admins ?? []).map((ga) => ({
+      name: ga.name,
+      email: ga.email,
+    })),
+    ...(groupMembers?.group.data ?? {}),
+  };
+
+  const [showDetails] = useConfirmationDialog(
+    {
+      title: "Group Details",
+      message: () => {
+        return <ObjectTree obj={details} />;
+      },
+      buttons: ["OK"],
+    },
+    [details],
+  );
+
+  const handleViewDetails = async () => {
+    await showDetails();
+  };
+
+  const [confirmRemove] = useConfirmationDialog(
+    {
+      title: `Remove account from group`,
+      message: `You are about to request removal of account ${removing?.name} from group ${groupMembers?.group.name}`,
+    },
+    [removing, groupMembers],
+  );
+
+  const handleRemove = async (account: AccountModel) => {
+    setRemoving(account);
+    const [confirmed] = await confirmRemove();
+    if (confirmed) {
+      const request = authenticatedFetch(
+        `/api/${clusterName}/group/RequestRemoveMember`,
+        {
+          method: "POST",
+          body: JSON.stringify({ groupId, accountId: account.id }),
+        },
+      );
+      setNotification(
+        request,
+        "Requesting removal of group member",
+        "Removal of group member requested",
+        async (r) => {
+          if (r.status === 400) {
+            const errors = await parseBadRequest(response);
+            return errors;
+          } else {
+            return "An error happened, please try again.";
+          }
+        },
+      );
+
+      const response = await request;
+      if (response.ok) {
+        setGroupMembers((groupMembersModel) => ({
+          ...groupMembersModel,
+          kerberosPendingRemoval: [
+            ...groupMembersModel.kerberosPendingRemoval,
+            account.kerberos,
+          ],
+        }));
+      }
+    }
+    setRemoving(undefined);
+  };
+
+  if (groupMembers && !groupMembers.group) {
+    return <NotFound />;
+  }
+
+  const columnHelper = createColumnHelper<AccountModel>();
+
+  const columns = [
+    columnHelper.accessor("name", {
+      header: "Name",
+      id: "Name", // id required for only this column for some reason
+    }),
+    columnHelper.accessor("email", {
+      header: "Email",
+    }),
+    columnHelper.accessor("kerberos", {
+      header: "Kerberos",
+    }),
+    columnHelper.accessor(
+      (row) => new Date(row.updatedOn).toLocaleDateString(),
+      {
+        header: "Updated On",
+      },
+    ),
+    columnHelper.accessor((row) => row.tags?.join(", "), {
+      header: "Tags",
+    }),
+    columnHelper.display({
+      id: "actions",
+      header: "Action",
+      cell: (props) => {
+        const removalPending = groupMembers.kerberosPendingRemoval.some(
+          (kerb) => props.row.original.kerberos === kerb,
+        );
+        return (
+          <>
+            <HipButton
+              disabled={removalPending}
+              onClick={() => handleRemove(props.row.original)}
+            >
+              {removalPending
+                ? "Removal Pending"
+                : removing?.id === props.row.original.id
+                  ? "Requesting Removal..."
+                  : "Remove from Group"}
+            </HipButton>
+          </>
+        );
+      },
+    }),
+  ];
+
+  const Title = (
+    <HipTitle title="Group Member Accounts" subtitle="Administration" />
+  );
+  if (groupMembers === undefined) {
+    return (
+      <HipMainWrapper>
+        {Title}
+        <HipBody>
+          <HipLoading />
+        </HipBody>
+      </HipMainWrapper>
+    );
+  }
+
+  return (
+    <HipMainWrapper>
+      {Title}
+      <HipBody>
+        <p>
+          <GroupInfo
+            group={groupMembers.group}
+            showDetails={handleViewDetails}
+          />
+        </p>
+        <HipTable
+          columns={columns}
+          data={groupMembers.accounts}
+          initialState={{
+            sorting: [
+              { id: "Groups", desc: false },
+              { id: "Name", desc: false },
+            ],
+          }}
+        />
+      </HipBody>
+    </HipMainWrapper>
+  );
+};
+
+export default GroupMembers;

--- a/Hippo.Web/ClientApp/src/components/Group/GroupNameWithTooltip.tsx
+++ b/Hippo.Web/ClientApp/src/components/Group/GroupNameWithTooltip.tsx
@@ -3,6 +3,7 @@ import { GroupInfo } from "./GroupInfo";
 import { useConfirmationDialog } from "../../Shared/ConfirmationDialog";
 import GroupDetails from "./GroupDetails";
 import { HipTooltip } from "../../Shared/HipComponents/HipTooltip";
+import { useMatch, useNavigate } from "react-router-dom";
 
 interface Props {
   group: GroupModel;
@@ -16,7 +17,7 @@ export const GroupNameWithTooltip = ({
   showDisplayName: useDisplayName = true,
 }: Props) => {
   const target = `groupName_${group.id}_${id ?? ""}`;
-  const [showDetails] = useConfirmationDialog(
+  const [handleShowDetails] = useConfirmationDialog(
     {
       title: "Group Details",
       message: () => {
@@ -26,13 +27,25 @@ export const GroupNameWithTooltip = ({
     },
     [group],
   );
+  const match = useMatch("/:cluster/*");
+  const cluster = match?.params.cluster;
+  const navigate = useNavigate();
+
+  const handleNavigateToGroupMembers = (group: GroupModel) => {
+    navigate(`/${cluster}/group/${group.id}`);
+  };
+
   return (
     <span className="dotted-underline">
       <span id={target} style={{ whiteSpace: "nowrap" }}>
         {useDisplayName ? group.displayName : group.name}
       </span>
       <HipTooltip placement="left" target={target}>
-        <GroupInfo group={group} showDetails={() => showDetails()} />
+        <GroupInfo
+          group={group}
+          showDetails={() => handleShowDetails()}
+          navigateToGroupMembers={() => handleNavigateToGroupMembers(group)}
+        />
       </HipTooltip>
     </span>
   );

--- a/Hippo.Web/ClientApp/src/types.ts
+++ b/Hippo.Web/ClientApp/src/types.ts
@@ -398,3 +398,9 @@ export interface PaymentReportModel {
   nextPaymentDate: string;
   orderCreatedOn: string;
 }
+
+export interface GroupMembersModel {
+  group: GroupModel;
+  accounts: AccountModel[];
+  kerberosPendingRemoval: string[];
+}

--- a/Hippo.Web/Models/GroupMemberModel.cs
+++ b/Hippo.Web/Models/GroupMemberModel.cs
@@ -1,0 +1,11 @@
+using Hippo.Core.Models;
+
+namespace Hippo.Web.Models
+{
+
+    public class GroupMemberModel
+    {
+        public int GroupId { get; set; }
+        public int AccountId { get; set; }
+    }
+}

--- a/Hippo.Web/Models/GroupMembersModel.cs
+++ b/Hippo.Web/Models/GroupMembersModel.cs
@@ -1,0 +1,12 @@
+using Hippo.Core.Models;
+
+namespace Hippo.Web.Models
+{
+
+    public class GroupMembersModel
+    {
+        public GroupModel Group { get; set; } = new();
+        public List<AccountModel> Accounts { get; set; } = new();
+        public List<string> KerberosPendingRemoval { get; set; } = new();
+    }
+}


### PR DESCRIPTION
I ended up not going the route of filtering accounts via a complex join against json data in QueuedEvent. Instead it gets a list of kerbs from the QueuedEvents json data and lets the front end indicate `Removal Pending` for those accounts.

![image](https://github.com/user-attachments/assets/a25bc166-37ea-4997-82e4-5347ee1b5e40)
![image](https://github.com/user-attachments/assets/f0b393b7-e982-436b-9e6a-666bc9e49d39)


Closes #298 