### PR TITLE
Require AUP agreement on account request and when AUP changes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
       "request": "launch",
       "preLaunchTask": "buildWeb",
       // If you have changed target frameworks, make sure to update the program path.
-      "program": "${workspaceFolder}/Hippo.Web/bin/Debug/net6.0/Hippo.Web.dll",
+      "program": "${workspaceFolder}/Hippo.Web/bin/Debug/net8.0/Hippo.Web.dll",
       "args": [],
       "cwd": "${workspaceFolder}/Hippo.Web",
       "stopAtEntry": false,
@@ -36,7 +36,7 @@
       "type": "coreclr",
       "request": "launch",
       "preLaunchTask": "buildPuppetSync",
-      "program": "${workspaceFolder}/Hippo.Jobs.PuppetSync/bin/Debug/net6.0/Hippo.Jobs.PuppetSync.dll",
+      "program": "${workspaceFolder}/Hippo.Jobs.PuppetSync/bin/Debug/net8.0/Hippo.Jobs.PuppetSync.dll",
       "args": [],
       "cwd": "${workspaceFolder}/Hippo.Jobs.PuppetSync",
       "stopAtEntry": false,

--- a/Hippo.Core/Domain/Account.cs
+++ b/Hippo.Core/Domain/Account.cs
@@ -52,6 +52,8 @@ namespace Hippo.Core.Domain
         public int ClusterId { get; set; }
         public Cluster Cluster { get; set; }
 
+        public DateTime? AcceptableUsePolicyAgreedOn { get; set; }
+
         [JsonIgnore]
         public List<Group> MemberOfGroups { get; set; } = new();
 

--- a/Hippo.Core/Domain/Cluster.cs
+++ b/Hippo.Core/Domain/Cluster.cs
@@ -32,6 +32,9 @@ namespace Hippo.Core.Domain
         [MaxLength(250)]
         [EmailAddress]
         public string Email { get; set; } = String.Empty;
+        [MaxLength(250)]
+        public string AcceptableUsePolicyUrl { get; set; } = String.Empty;
+        public DateTime? AcceptableUsePolicyUpdatedOn { get; set; }
 
 
         [JsonIgnore]

--- a/Hippo.Core/Extensions/ClusterExtensions.cs
+++ b/Hippo.Core/Extensions/ClusterExtensions.cs
@@ -20,6 +20,8 @@ public static class ClusterExtensions
             IsActive = model.IsActive,
             Domain = model.Domain,
             Email = model.Email,
+            AcceptableUsePolicyUrl = model.AcceptableUsePolicyUrl,
+            AcceptableUsePolicyUpdatedOn = model.AcceptableUsePolicyUpdatedOn,
             AccessTypes = model.AccessTypes.Any() 
                 ? await dbContext.AccessTypes.Where(at => model.AccessTypes.Contains(at.Name)).ToListAsync() 
                 : new()

--- a/Hippo.Core/Migrations/SqlServer/20250401203634_AcceptableUse.Designer.cs
+++ b/Hippo.Core/Migrations/SqlServer/20250401203634_AcceptableUse.Designer.cs
@@ -4,6 +4,7 @@ using Hippo.Core.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Hippo.Core.Migrations.SqlServer
 {
     [DbContext(typeof(AppDbContextSqlServer))]
-    partial class AppDbContextSqlServerModelSnapshot : ModelSnapshot
+    [Migration("20250401203634_AcceptableUse")]
+    partial class AcceptableUse
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Hippo.Core/Migrations/SqlServer/20250401203634_AcceptableUse.cs
+++ b/Hippo.Core/Migrations/SqlServer/20250401203634_AcceptableUse.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Hippo.Core.Migrations.SqlServer
+{
+    /// <inheritdoc />
+    public partial class AcceptableUse : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "AcceptableUsePolicyUpdatedOn",
+                table: "Clusters",
+                type: "datetime2",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "AcceptableUsePolicyUrl",
+                table: "Clusters",
+                type: "nvarchar(250)",
+                maxLength: 250,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "AcceptableUsePolicyAgreedOn",
+                table: "Accounts",
+                type: "datetime2",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AcceptableUsePolicyUpdatedOn",
+                table: "Clusters");
+
+            migrationBuilder.DropColumn(
+                name: "AcceptableUsePolicyUrl",
+                table: "Clusters");
+
+            migrationBuilder.DropColumn(
+                name: "AcceptableUsePolicyAgreedOn",
+                table: "Accounts");
+        }
+    }
+}

--- a/Hippo.Core/Migrations/Sqlite/20250401203623_AcceptableUse.Designer.cs
+++ b/Hippo.Core/Migrations/Sqlite/20250401203623_AcceptableUse.Designer.cs
@@ -3,32 +3,30 @@ using System;
 using Hippo.Core.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace Hippo.Core.Migrations.SqlServer
+namespace Hippo.Core.Migrations.Sqlite
 {
-    [DbContext(typeof(AppDbContextSqlServer))]
-    partial class AppDbContextSqlServerModelSnapshot : ModelSnapshot
+    [DbContext(typeof(AppDbContextSqlite))]
+    [Migration("20250401203623_AcceptableUse")]
+    partial class AcceptableUse
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder
-                .HasAnnotation("ProductVersion", "8.0.14")
-                .HasAnnotation("Relational:MaxIdentifierLength", 128);
-
-            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
+            modelBuilder.HasAnnotation("ProductVersion", "8.0.14");
 
             modelBuilder.Entity("AccessTypeAccount", b =>
                 {
                     b.Property<int>("AccessTypesId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("AccountsId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("AccessTypesId", "AccountsId");
 
@@ -40,10 +38,10 @@ namespace Hippo.Core.Migrations.SqlServer
             modelBuilder.Entity("AccessTypeCluster", b =>
                 {
                     b.Property<int>("AccessTypesId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("ClustersId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("AccessTypesId", "ClustersId");
 
@@ -55,10 +53,10 @@ namespace Hippo.Core.Migrations.SqlServer
             modelBuilder.Entity("AccountTag", b =>
                 {
                     b.Property<int>("AccountsId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("TagsId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("AccountsId", "TagsId");
 
@@ -71,14 +69,12 @@ namespace Hippo.Core.Migrations.SqlServer
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -92,42 +88,40 @@ namespace Hippo.Core.Migrations.SqlServer
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime?>("AcceptableUsePolicyAgreedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("ClusterId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Data")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Email")
                         .HasMaxLength(300)
-                        .HasColumnType("nvarchar(300)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Kerberos")
                         .HasMaxLength(20)
-                        .HasColumnType("nvarchar(20)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Name")
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("OwnerId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("SshKey")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("UpdatedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -152,23 +146,21 @@ namespace Hippo.Core.Migrations.SqlServer
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("ChartString")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("OrderId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<decimal>("Percentage")
-                        .HasColumnType("decimal(18,2)");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("Updated")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -181,51 +173,49 @@ namespace Hippo.Core.Migrations.SqlServer
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime?>("AcceptableUsePolicyUpdatedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("AcceptableUsePolicyUrl")
                         .HasMaxLength(250)
-                        .HasColumnType("nvarchar(250)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Description")
                         .IsRequired()
                         .HasMaxLength(250)
-                        .HasColumnType("nvarchar(250)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Domain")
                         .HasMaxLength(250)
-                        .HasColumnType("nvarchar(250)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Email")
                         .HasMaxLength(250)
-                        .HasColumnType("nvarchar(250)");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("IsActive")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("bit")
+                        .HasColumnType("INTEGER")
                         .HasDefaultValue(true);
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(20)
-                        .HasColumnType("nvarchar(20)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("SshKeyId")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("SshName")
                         .HasMaxLength(250)
-                        .HasColumnType("nvarchar(250)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("SshUrl")
                         .HasMaxLength(250)
-                        .HasColumnType("nvarchar(250)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -238,30 +228,28 @@ namespace Hippo.Core.Migrations.SqlServer
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                        .HasColumnType("INTEGER");
 
                     b.Property<bool>("AutoApprove")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("bit")
+                        .HasColumnType("INTEGER")
                         .HasDefaultValue(true);
 
                     b.Property<string>("ChartString")
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("ClusterId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("FinancialSystemApiSource")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("SecretAccessKey")
                         .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -275,24 +263,22 @@ namespace Hippo.Core.Migrations.SqlServer
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("ClusterId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Data")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("DisplayName")
                         .HasMaxLength(250)
-                        .HasColumnType("nvarchar(250)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(32)
-                        .HasColumnType("nvarchar(32)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -305,10 +291,10 @@ namespace Hippo.Core.Migrations.SqlServer
             modelBuilder.Entity("Hippo.Core.Domain.GroupAdminAccount", b =>
                 {
                     b.Property<int>("AccountId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("GroupId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("AccountId", "GroupId");
 
@@ -320,10 +306,10 @@ namespace Hippo.Core.Migrations.SqlServer
             modelBuilder.Entity("Hippo.Core.Domain.GroupMemberAccount", b =>
                 {
                     b.Property<int>("AccountId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("GroupId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("AccountId", "GroupId");
 
@@ -336,39 +322,37 @@ namespace Hippo.Core.Migrations.SqlServer
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                        .HasColumnType("INTEGER");
 
                     b.Property<int?>("ActedById")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("ActedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Action")
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("AdminAction")
-                        .HasColumnType("bit");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int?>("ClusterId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Details")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("OrderId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Status")
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Type")
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -391,103 +375,101 @@ namespace Hippo.Core.Migrations.SqlServer
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                        .HasColumnType("INTEGER");
 
                     b.Property<decimal>("Adjustment")
-                        .HasColumnType("decimal(18,2)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("AdjustmentReason")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("AdminNotes")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<decimal>("BalanceRemaining")
-                        .HasColumnType("decimal(18,2)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Category")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("ClusterId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Description")
                         .IsRequired()
                         .HasMaxLength(250)
-                        .HasColumnType("nvarchar(250)");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("ExpirationDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ExternalReference")
                         .HasMaxLength(150)
-                        .HasColumnType("nvarchar(150)");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("InstallmentDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("InstallmentType")
                         .IsRequired()
                         .HasMaxLength(10)
-                        .HasColumnType("nvarchar(10)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("Installments")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<bool>("IsRecurring")
-                        .HasColumnType("bit");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("LifeCycle")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("NextNotificationDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("NextPaymentDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Notes")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("PrincipalInvestigatorId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("ProductName")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("TEXT");
 
                     b.Property<decimal>("Quantity")
-                        .HasColumnType("decimal(18,2)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Status")
                         .HasMaxLength(20)
-                        .HasColumnType("nvarchar(20)");
+                        .HasColumnType("TEXT");
 
                     b.Property<decimal>("SubTotal")
-                        .HasColumnType("decimal(18,2)");
+                        .HasColumnType("TEXT");
 
                     b.Property<decimal>("Total")
-                        .HasColumnType("decimal(18,2)");
+                        .HasColumnType("TEXT");
 
                     b.Property<decimal>("UnitPrice")
-                        .HasColumnType("decimal(18,2)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Units")
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -512,22 +494,20 @@ namespace Hippo.Core.Migrations.SqlServer
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("OrderId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Value")
                         .IsRequired()
                         .HasMaxLength(450)
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -542,39 +522,37 @@ namespace Hippo.Core.Migrations.SqlServer
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                        .HasColumnType("INTEGER");
 
                     b.Property<decimal>("Amount")
-                        .HasColumnType("decimal(18,2)");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("CompletedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("CreatedById")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Details")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("FinancialSystemId")
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("OrderId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Status")
                         .HasMaxLength(20)
-                        .HasColumnType("nvarchar(20)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TrackingNumber")
                         .HasMaxLength(20)
-                        .HasColumnType("nvarchar(20)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -591,18 +569,16 @@ namespace Hippo.Core.Migrations.SqlServer
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                        .HasColumnType("INTEGER");
 
                     b.Property<int?>("ClusterId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("RoleId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("UserId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("Id");
 
@@ -619,62 +595,60 @@ namespace Hippo.Core.Migrations.SqlServer
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Category")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("ClusterId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Description")
                         .IsRequired()
                         .HasMaxLength(250)
-                        .HasColumnType("nvarchar(250)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("InstallmentType")
                         .IsRequired()
                         .HasMaxLength(10)
-                        .HasColumnType("nvarchar(10)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("Installments")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<bool>("IsActive")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("bit")
+                        .HasColumnType("INTEGER")
                         .HasDefaultValue(true);
 
                     b.Property<bool>("IsHiddenFromPublic")
-                        .HasColumnType("bit");
+                        .HasColumnType("INTEGER");
 
                     b.Property<bool>("IsRecurring")
-                        .HasColumnType("bit");
+                        .HasColumnType("INTEGER");
 
                     b.Property<bool>("IsUnavailable")
-                        .HasColumnType("bit");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("LastUpdated")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("LifeCycle")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("TEXT");
 
                     b.Property<decimal>("UnitPrice")
-                        .HasColumnType("decimal(18,2)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Units")
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -687,32 +661,30 @@ namespace Hippo.Core.Migrations.SqlServer
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Action")
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Data")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ErrorMessage")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("RequestId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Status")
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("UpdatedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -733,48 +705,46 @@ namespace Hippo.Core.Migrations.SqlServer
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Action")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("ActorId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("ClusterId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Data")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Group")
                         .HasMaxLength(32)
-                        .HasColumnType("nvarchar(32)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("RequesterId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("SshKey")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Status")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("SupervisingPI")
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("UpdatedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -797,14 +767,12 @@ namespace Hippo.Core.Migrations.SqlServer
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -818,17 +786,15 @@ namespace Hippo.Core.Migrations.SqlServer
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("ClusterId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -840,10 +806,10 @@ namespace Hippo.Core.Migrations.SqlServer
             modelBuilder.Entity("Hippo.Core.Domain.TempGroup", b =>
                 {
                     b.Property<int>("ClusterId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Group")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("ClusterId", "Group");
 
@@ -853,10 +819,10 @@ namespace Hippo.Core.Migrations.SqlServer
             modelBuilder.Entity("Hippo.Core.Domain.TempKerberos", b =>
                 {
                     b.Property<int>("ClusterId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Kerberos")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("ClusterId", "Kerberos");
 
@@ -867,44 +833,41 @@ namespace Hippo.Core.Migrations.SqlServer
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Email")
                         .IsRequired()
                         .HasMaxLength(300)
-                        .HasColumnType("nvarchar(300)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("FirstName")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Iam")
                         .HasMaxLength(10)
-                        .HasColumnType("nvarchar(10)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Kerberos")
                         .HasMaxLength(20)
-                        .HasColumnType("nvarchar(20)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("LastName")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("MothraId")
                         .HasMaxLength(20)
-                        .HasColumnType("nvarchar(20)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
                     b.HasIndex("Email");
 
                     b.HasIndex("Iam")
-                        .IsUnique()
-                        .HasFilter("[Iam] IS NOT NULL");
+                        .IsUnique();
 
                     b.ToTable("Users");
                 });

--- a/Hippo.Core/Migrations/Sqlite/20250401203623_AcceptableUse.cs
+++ b/Hippo.Core/Migrations/Sqlite/20250401203623_AcceptableUse.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Hippo.Core.Migrations.Sqlite
+{
+    /// <inheritdoc />
+    public partial class AcceptableUse : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "AcceptableUsePolicyUpdatedOn",
+                table: "Clusters",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "AcceptableUsePolicyUrl",
+                table: "Clusters",
+                type: "TEXT",
+                maxLength: 250,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "AcceptableUsePolicyAgreedOn",
+                table: "Accounts",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AcceptableUsePolicyUpdatedOn",
+                table: "Clusters");
+
+            migrationBuilder.DropColumn(
+                name: "AcceptableUsePolicyUrl",
+                table: "Clusters");
+
+            migrationBuilder.DropColumn(
+                name: "AcceptableUsePolicyAgreedOn",
+                table: "Accounts");
+        }
+    }
+}

--- a/Hippo.Core/Migrations/Sqlite/AppDbContextSqliteModelSnapshot.cs
+++ b/Hippo.Core/Migrations/Sqlite/AppDbContextSqliteModelSnapshot.cs
@@ -15,7 +15,7 @@ namespace Hippo.Core.Migrations.Sqlite
         protected override void BuildModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder.HasAnnotation("ProductVersion", "6.0.19");
+            modelBuilder.HasAnnotation("ProductVersion", "8.0.14");
 
             modelBuilder.Entity("AccessTypeAccount", b =>
                 {
@@ -86,6 +86,9 @@ namespace Hippo.Core.Migrations.Sqlite
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("INTEGER");
+
+                    b.Property<DateTime?>("AcceptableUsePolicyAgreedOn")
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("ClusterId")
                         .HasColumnType("INTEGER");
@@ -168,6 +171,13 @@ namespace Hippo.Core.Migrations.Sqlite
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("INTEGER");
+
+                    b.Property<DateTime?>("AcceptableUsePolicyUpdatedOn")
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("AcceptableUsePolicyUrl")
+                        .HasMaxLength(250)
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Description")
                         .IsRequired()

--- a/Hippo.Core/Models/AccountDetail.cs
+++ b/Hippo.Core/Models/AccountDetail.cs
@@ -10,6 +10,7 @@ namespace Hippo.Core.Models
         public string Owner { get; set; }
         public string Cluster { get; set; }
         public JsonElement? Data { get; set; }
+        public DateTime? AcceptableUsePolicyAgreedOn { get; set; }
         public List<GroupModel> MemberOfGroups { get; set; } = new();
         public List<GroupModel> AdminOfGroups { get; set; } = new();
     }

--- a/Hippo.Core/Models/ClusterModel.cs
+++ b/Hippo.Core/Models/ClusterModel.cs
@@ -35,7 +35,7 @@ public class ClusterModel
     public List<string> AccessTypes { get; set; } = new();
     [MaxLength(250)]
     [Url]
-    public string AcceptableUsePolicyUrl { get; set; } = String.Empty;
+    public string AcceptableUsePolicyUrl { get; set; } = null;
     public DateTime? AcceptableUsePolicyUpdatedOn { get; set; }
     public bool AllowOrders { get; set; } = false;
 

--- a/Hippo.Core/Models/ClusterModel.cs
+++ b/Hippo.Core/Models/ClusterModel.cs
@@ -33,7 +33,10 @@ public class ClusterModel
     public string SshKey { get; set; } = String.Empty;
     [ListOfStringsOptions(AccessType.Codes.RegexPattern, nonEmpty: true)]
     public List<string> AccessTypes { get; set; } = new();
-
+    [MaxLength(250)]
+    [Url]
+    public string AcceptableUsePolicyUrl { get; set; } = String.Empty;
+    public DateTime? AcceptableUsePolicyUpdatedOn { get; set; }
     public bool AllowOrders { get; set; } = false;
 
     public ClusterModel()
@@ -54,6 +57,8 @@ public class ClusterModel
         Email = cluster.Email;
         AccessTypes = cluster.AccessTypes.Select(at => at.Name).ToList();
         SshKey = sshKey;
+        AcceptableUsePolicyUrl = cluster.AcceptableUsePolicyUrl;
+        AcceptableUsePolicyUpdatedOn = cluster.AcceptableUsePolicyUpdatedOn;
     }
 
     public static Expression<Func<Cluster, ClusterModel>> Projection
@@ -72,8 +77,9 @@ public class ClusterModel
                 Domain = c.Domain,
                 Email = c.Email,
                 AllowOrders = c.FinancialDetail != null,
-                AccessTypes = c.AccessTypes.Select(at => at.Name).ToList()
-            
+                AccessTypes = c.AccessTypes.Select(at => at.Name).ToList(),
+                AcceptableUsePolicyUrl = c.AcceptableUsePolicyUrl,
+                AcceptableUsePolicyUpdatedOn = c.AcceptableUsePolicyUpdatedOn
             };
         }
     }

--- a/Hippo.Core/Models/RequestModel.cs
+++ b/Hippo.Core/Models/RequestModel.cs
@@ -23,6 +23,7 @@ namespace Hippo.Core.Models
 
     public class AccountRequestDataModel
     {
+        public DateTime? AcceptableUsePolicyAgreedOn { get; set; }
         [MaxLength(100)]
         public string SupervisingPI { get; set; } = "";
         public string SshKey { get; set; } = "";

--- a/Hippo.Core/Services/UserService.cs
+++ b/Hippo.Core/Services/UserService.cs
@@ -118,6 +118,7 @@ namespace Hippo.Core.Services
                     Owner = a.Owner.Name,
                     Cluster = a.Cluster.Name,
                     Data = a.Data,
+                    AcceptableUsePolicyAgreedOn = a.AcceptableUsePolicyAgreedOn,
                     MemberOfGroups = a.MemberOfGroups.Select(g => new GroupModel
                     {
                         Id = g.Id,

--- a/Hippo.Web/ClientApp/src/App.tsx
+++ b/Hippo.Web/ClientApp/src/App.tsx
@@ -35,8 +35,9 @@ import { FinancialAdmins } from "./components/Admin/FinancialAdmins";
 import { Payments } from "./components/Report/Payments";
 import { ReportOrders } from "./components/Report/ReportOrders";
 import GroupMembers from "./components/Group/GroupMembers";
+import { RequireAupAgreement } from "./Shared/RequireAupAgreement";
 
-declare var Hippo: AppContextShape;
+declare let Hippo: AppContextShape;
 
 const App = () => {
   const [context, setContext] = useState<AppContextShape>(Hippo);
@@ -61,14 +62,23 @@ const App = () => {
             <Route path="/" element={<Home />} />
             <Route path="/clusters" element={<Clusters />} />
             <Route path="/:cluster" element={<ClusterHome />} />
-            <Route path="/:cluster/myaccount" element={<AccountInfo />} />
+            <Route
+              path="/:cluster/myaccount"
+              element={
+                <RequireAupAgreement>
+                  <AccountInfo />
+                </RequireAupAgreement>
+              }
+            />
             <Route path="/:cluster/accountstatus" element={<AccountStatus />} />
             <Route path="/:cluster/create" element={<RequestForm />} />
             <Route
               path="/:cluster/approve"
               element={
                 <ShowFor roles={["GroupAdmin"]} alternative={<NotAuthorized />}>
-                  <Requests />
+                  <RequireAupAgreement>
+                    <Requests />
+                  </RequireAupAgreement>
                 </ShowFor>
               }
             />
@@ -76,7 +86,9 @@ const App = () => {
               path="/:cluster/activeaccounts"
               element={
                 <ShowFor roles={["GroupAdmin"]} alternative={<NotAuthorized />}>
-                  <ActiveAccounts />
+                  <RequireAupAgreement>
+                    <ActiveAccounts />
+                  </RequireAupAgreement>
                 </ShowFor>
               }
             />
@@ -87,7 +99,9 @@ const App = () => {
                   roles={["ClusterAdmin"]}
                   alternative={<NotAuthorized />}
                 >
-                  <Groups />
+                  <RequireAupAgreement>
+                    <Groups />
+                  </RequireAupAgreement>
                 </ShowFor>
               }
             />
@@ -98,7 +112,9 @@ const App = () => {
                   roles={["ClusterAdmin"]}
                   alternative={<NotAuthorized />}
                 >
-                  <ClusterAdmins />
+                  <RequireAupAgreement>
+                    <ClusterAdmins />
+                  </RequireAupAgreement>
                 </ShowFor>
               }
             />
@@ -109,7 +125,9 @@ const App = () => {
                   roles={["ClusterAdmin"]}
                   alternative={<NotAuthorized />}
                 >
-                  <FinancialAdmins />
+                  <RequireAupAgreement>
+                    <FinancialAdmins />
+                  </RequireAupAgreement>
                 </ShowFor>
               }
             />
@@ -128,7 +146,9 @@ const App = () => {
                   roles={["System", "FinancialAdmin"]}
                   alternative={<NotAuthorized />}
                 >
-                  <FinancialDetail />
+                  <RequireAupAgreement>
+                    <FinancialDetail />
+                  </RequireAupAgreement>
                 </ShowFor>
               }
             />
@@ -144,7 +164,9 @@ const App = () => {
                   ]}
                   alternative={<NotAuthorized />}
                 >
-                  <Products />
+                  <RequireAupAgreement>
+                    <Products />
+                  </RequireAupAgreement>
                 </ShowFor>
               }
             />
@@ -160,7 +182,9 @@ const App = () => {
                   ]}
                   alternative={<NotAuthorized />}
                 >
-                  <Orders />
+                  <RequireAupAgreement>
+                    <Orders />
+                  </RequireAupAgreement>
                 </ShowFor>
               }
             />
@@ -176,7 +200,9 @@ const App = () => {
                   ]}
                   alternative={<NotAuthorized />}
                 >
-                  <Details />
+                  <RequireAupAgreement>
+                    <Details />
+                  </RequireAupAgreement>
                 </ShowFor>
               }
             />
@@ -192,7 +218,9 @@ const App = () => {
                   ]}
                   alternative={<NotAuthorized />}
                 >
-                  <OrderHistories />
+                  <RequireAupAgreement>
+                    <OrderHistories />
+                  </RequireAupAgreement>
                 </ShowFor>
               }
             />
@@ -208,7 +236,9 @@ const App = () => {
                   ]}
                   alternative={<NotAuthorized />}
                 >
-                  <OrderPayments />
+                  <RequireAupAgreement>
+                    <OrderPayments />
+                  </RequireAupAgreement>
                 </ShowFor>
               }
             />
@@ -219,7 +249,9 @@ const App = () => {
                   roles={["System", "ClusterAdmin", "GroupAdmin"]}
                   alternative={<NotAuthorized />}
                 >
-                  <EditOrder />
+                  <RequireAupAgreement>
+                    <EditOrder />
+                  </RequireAupAgreement>
                 </ShowFor>
               }
             />
@@ -235,7 +267,9 @@ const App = () => {
                   ]}
                   alternative={<NotAuthorized />}
                 >
-                  <UpdateChartStrings />
+                  <RequireAupAgreement>
+                    <UpdateChartStrings />
+                  </RequireAupAgreement>
                 </ShowFor>
               }
             />
@@ -246,7 +280,9 @@ const App = () => {
                   roles={["System", "ClusterAdmin", "GroupAdmin"]}
                   alternative={<NotAuthorized />}
                 >
-                  <CreateOrder />
+                  <RequireAupAgreement>
+                    <CreateOrder />
+                  </RequireAupAgreement>
                 </ShowFor>
               }
             />
@@ -257,7 +293,9 @@ const App = () => {
                   roles={["System", "ClusterAdmin", "FinancialAdmin"]}
                   alternative={<NotAuthorized />}
                 >
-                  <Payments />
+                  <RequireAupAgreement>
+                    <Payments />
+                  </RequireAupAgreement>
                 </ShowFor>
               }
             />
@@ -268,7 +306,9 @@ const App = () => {
                   roles={["System", "ClusterAdmin", "FinancialAdmin"]}
                   alternative={<NotAuthorized />}
                 >
-                  <ReportOrders />
+                  <RequireAupAgreement>
+                    <ReportOrders />
+                  </RequireAupAgreement>
                 </ShowFor>
               }
             />
@@ -279,7 +319,9 @@ const App = () => {
                   roles={["System", "ClusterAdmin", "GroupAdmin"]}
                   alternative={<NotAuthorized />}
                 >
-                  <GroupMembers />
+                  <RequireAupAgreement>
+                    <GroupMembers />
+                  </RequireAupAgreement>
                 </ShowFor>
               }
             />

--- a/Hippo.Web/ClientApp/src/Shared/RequireAupAgreement.tsx
+++ b/Hippo.Web/ClientApp/src/Shared/RequireAupAgreement.tsx
@@ -22,6 +22,9 @@ export const RequireAupAgreement = (props: Props) => {
   const hasSystemPermission = context.user.permissions.some(
     (p) => p.role === "System",
   );
+  const hasFinancialAdminPermission = context.user.permissions.some(
+    (p) => p.role === "FinancialAdmin",
+  );
   const cluster = context.clusters.find((c) => c.name === clusterName);
   const account = context.accounts.find((a) => a.cluster === clusterName);
 
@@ -85,9 +88,11 @@ export const RequireAupAgreement = (props: Props) => {
     const request = currentOpenRequests.find(
       (r) => r.cluster === clusterName && r.action === "CreateAccount",
     );
-    if (request) {
+    if (request || hasFinancialAdminPermission) {
       // A pending account creation request implies the AUP has already
       // been agreed to, so it's okay to show the child components
+
+      // A financialAdmin without an account does not need to agree to the AUP
       return <>{children}</>;
     }
   }

--- a/Hippo.Web/ClientApp/src/Shared/RequireAupAgreement.tsx
+++ b/Hippo.Web/ClientApp/src/Shared/RequireAupAgreement.tsx
@@ -1,0 +1,141 @@
+import React, { useContext, useMemo, useState } from "react";
+
+import AppContext from "./AppContext";
+import { useMatch } from "react-router-dom";
+import HipBody from "./Layout/HipBody";
+import HipMainWrapper from "./Layout/HipMainWrapper";
+import HipTitle from "./Layout/HipTitle";
+import HipButton from "./HipComponents/HipButton";
+import { usePromiseNotification } from "../util/Notifications";
+import { authenticatedFetch, parseBadRequest } from "../util/api";
+
+interface Props {
+  children: any;
+}
+
+export const RequireAupAgreement = (props: Props) => {
+  const { children } = props;
+  const [context, setContext] = useContext(AppContext);
+  const match = useMatch("/:cluster/*");
+  const clusterName = match?.params.cluster;
+  const [hasAgreedToAup, setHasAgreedToAup] = useState(false);
+  const [notification, setNotification] = usePromiseNotification();
+
+  const cluster = context.clusters.find((c) => c.name === clusterName);
+  const account = context.accounts.find((a) => a.cluster === clusterName);
+
+  const currentOpenRequests = useMemo(
+    () => context.openRequests.filter((r) => r.cluster === clusterName),
+    [context.openRequests, clusterName],
+  );
+
+  const handleAgreetoAup = async () => {
+    const request = authenticatedFetch(
+      `/api/${clusterName}/account/agreeToAup/`,
+      {
+        method: "POST",
+      },
+    );
+
+    setNotification(
+      request,
+      "Agreeing to AUP",
+      "Agreement Received",
+      async (r) => {
+        if (r.status === 400) {
+          const errors = await parseBadRequest(response);
+          return errors;
+        } else {
+          return "An error happened, please try again.";
+        }
+      },
+    );
+
+    const response = await request;
+    if (response.ok) {
+      // Updating context here should cause a rerender which will pick up the new agreedOn
+      // date and allow the children to be passed through
+      setContext((prevContext) => ({
+        ...prevContext,
+        accounts: prevContext.accounts.map((a) =>
+          a.cluster === clusterName
+            ? { ...a, acceptableUsePolicyAgreedOn: new Date().toISOString() }
+            : a,
+        ),
+      }));
+    }
+  };
+
+  if (
+    !cluster.acceptableUsePolicyUrl ||
+    !cluster.acceptableUsePolicyUpdatedOn
+  ) {
+    // cluster doesn't have an AUP, so no verification necessary
+    return <>{children}</>;
+  }
+
+  if (!account) {
+    const request = currentOpenRequests.find(
+      (r) => r.cluster === clusterName && r.action === "CreateAccount",
+    );
+    if (request) {
+      // A pending account creation request implies the AUP has already
+      // been agreed to, so it's okay to show the child components
+      return <>{children}</>;
+    }
+  }
+
+  if (
+    !account.acceptableUsePolicyAgreedOn ||
+    new Date(account.acceptableUsePolicyAgreedOn) <
+      new Date(cluster.acceptableUsePolicyUpdatedOn)
+  ) {
+    // User has not agreed to the latest AUP
+    return (
+      <HipMainWrapper>
+        <HipTitle
+          title={`Welcome, ${context.user.detail.firstName}`}
+          subtitle="Acceptable Use Policy"
+        />
+        <HipBody>
+          <p>
+            In order to continue accessing this cluster, you need to read and
+            agree to the cluster's latest Acceptable Use Policy
+          </p>
+          <hr />
+          <div className="form-group">
+            <input
+              id="fieldHasAgreedToAup"
+              type="checkbox"
+              checked={hasAgreedToAup}
+              onChange={(e) => {
+                setHasAgreedToAup(e.target.checked);
+              }}
+            />{" "}
+            <label htmlFor="fieldHasAgreedToAup">
+              I have read and agree to abide by the{" "}
+              <a
+                href={cluster.acceptableUsePolicyUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Acceptable Use Policy
+              </a>
+            </label>
+          </div>{" "}
+          <div>
+            <br />
+            <HipButton
+              disabled={notification.pending || !hasAgreedToAup}
+              onClick={() => handleAgreetoAup()}
+            >
+              Agree
+            </HipButton>{" "}
+          </div>
+        </HipBody>
+      </HipMainWrapper>
+    );
+  }
+
+  return <>{children}</>;
+};

--- a/Hippo.Web/ClientApp/src/components/Account/AccountInfo.tsx
+++ b/Hippo.Web/ClientApp/src/components/Account/AccountInfo.tsx
@@ -126,7 +126,7 @@ export const AccountInfo = () => {
                     id="displayName"
                     placeholder="Enter Display Name"
                     onChange={(e) =>
-                      setReturn((model) => ({
+                      setReturn((_) => ({
                         name: userGroupName,
                         displayName: e.target.value,
                       }))

--- a/Hippo.Web/ClientApp/src/components/Account/RequestForm.tsx
+++ b/Hippo.Web/ClientApp/src/components/Account/RequestForm.tsx
@@ -174,16 +174,7 @@ export const RequestForm = () => {
           cluster.acceptableUsePolicyUrl && (
             <>
               <div className="form-group">
-                <label htmlFor="fieldHasAgreedToAup">
-                  I have read and agree to abide by the{" "}
-                  <a
-                    href={cluster.acceptableUsePolicyUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Acceptable Use Policy
-                  </a>
-                </label>{" "}
+                <br />
                 <input
                   id="fieldHasAgreedToAup"
                   type="checkbox"
@@ -196,7 +187,17 @@ export const RequestForm = () => {
                         : undefined,
                     }));
                   }}
-                />
+                />{" "}
+                <label htmlFor="fieldHasAgreedToAup">
+                  I have read and agree to abide by the{" "}
+                  <a
+                    href={cluster.acceptableUsePolicyUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Acceptable Use Policy
+                  </a>
+                </label>
               </div>
             </>
           )}

--- a/Hippo.Web/ClientApp/src/components/Account/RequestForm.tsx
+++ b/Hippo.Web/ClientApp/src/components/Account/RequestForm.tsx
@@ -170,9 +170,46 @@ export const RequestForm = () => {
               />
             </div>
           )}
+        {cluster.acceptableUsePolicyUpdatedOn &&
+          cluster.acceptableUsePolicyUrl && (
+            <>
+              <div className="form-group">
+                <label htmlFor="fieldHasAgreedToAUP">
+                  I have read and agree to abide by the{" "}
+                  <a
+                    href={cluster.acceptableUsePolicyUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Acceptable Use Policy
+                  </a>
+                </label>{" "}
+                <input
+                  id="fieldHasAgreedToAUP"
+                  type="checkbox"
+                  checked={!!request.acceptableUsePolicyAgreedOn}
+                  onChange={(e) => {
+                    setRequest((r) => ({
+                      ...r,
+                      acceptableUsePolicyAgreedOn: e.target.checked
+                        ? new Date().toISOString()
+                        : undefined,
+                    }));
+                  }}
+                />
+              </div>
+            </>
+          )}
         <br />
         <HipButton
-          disabled={notification.pending || !request.accessTypes.length}
+          disabled={
+            notification.pending ||
+            !request.accessTypes.length ||
+            // if cluster has a AUP, then requester must agree
+            (cluster.acceptableUsePolicyUpdatedOn &&
+              cluster.acceptableUsePolicyUrl &&
+              !request.acceptableUsePolicyAgreedOn)
+          }
           onClick={handleSubmit}
         >
           Submit

--- a/Hippo.Web/ClientApp/src/components/Account/RequestForm.tsx
+++ b/Hippo.Web/ClientApp/src/components/Account/RequestForm.tsx
@@ -174,7 +174,7 @@ export const RequestForm = () => {
           cluster.acceptableUsePolicyUrl && (
             <>
               <div className="form-group">
-                <label htmlFor="fieldHasAgreedToAUP">
+                <label htmlFor="fieldHasAgreedToAup">
                   I have read and agree to abide by the{" "}
                   <a
                     href={cluster.acceptableUsePolicyUrl}
@@ -185,7 +185,7 @@ export const RequestForm = () => {
                   </a>
                 </label>{" "}
                 <input
-                  id="fieldHasAgreedToAUP"
+                  id="fieldHasAgreedToAup"
                   type="checkbox"
                   checked={!!request.acceptableUsePolicyAgreedOn}
                   onChange={(e) => {

--- a/Hippo.Web/ClientApp/src/components/Account/Requests.test.tsx
+++ b/Hippo.Web/ClientApp/src/components/Account/Requests.test.tsx
@@ -5,6 +5,7 @@ import {
   fakeGroupAdminAppContext,
   fakeGroups,
   fakeRequests,
+  fakeSetContext,
 } from "../../test/mockData";
 import { responseMap } from "../../test/testHelpers";
 
@@ -15,6 +16,8 @@ import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import userEvent from "@testing-library/user-event";
 import { act } from "react";
+import { RequireAupAgreement } from "../../Shared/RequireAupAgreement";
+import AppContext from "../../Shared/AppContext";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -106,14 +109,17 @@ it("shows reject button for each pending account", async () => {
 it("displays dialog when reject is clicked", async () => {
   const user = userEvent.setup();
   await act(async () => {
+    console.log("approveUrl", approveUrl);
     render(
-      <MemoryRouter initialEntries={[approveUrl]}>
-        <ModalProvider>
-          <Routes>
-            <Route path={"/:cluster/approve"} element={<Requests />} />
-          </Routes>
-        </ModalProvider>
-      </MemoryRouter>,
+      <AppContext.Provider value={[fakeGroupAdminAppContext, fakeSetContext]}>
+        <MemoryRouter initialEntries={[approveUrl]}>
+          <ModalProvider>
+            <Routes>
+              <Route path={"/:cluster/approve"} element={<Requests />} />
+            </Routes>
+          </ModalProvider>
+        </MemoryRouter>
+      </AppContext.Provider>,
     );
   });
   expect(
@@ -131,13 +137,15 @@ it("calls approve and filters list when approve is clicked", async () => {
   const user = userEvent.setup();
   await act(async () => {
     render(
-      <MemoryRouter initialEntries={[approveUrl]}>
-        <ModalProvider>
-          <Routes>
-            <Route path={"/:cluster/approve"} element={<Requests />} />
-          </Routes>
-        </ModalProvider>
-      </MemoryRouter>,
+      <AppContext.Provider value={[fakeGroupAdminAppContext, fakeSetContext]}>
+        <MemoryRouter initialEntries={[approveUrl]}>
+          <ModalProvider>
+            <Routes>
+              <Route path={"/:cluster/approve"} element={<Requests />} />
+            </Routes>
+          </ModalProvider>
+        </MemoryRouter>
+      </AppContext.Provider>,
     );
   });
   expect(

--- a/Hippo.Web/ClientApp/src/components/ClusterAdmin/Clusters.tsx
+++ b/Hippo.Web/ClientApp/src/components/ClusterAdmin/Clusters.tsx
@@ -191,7 +191,8 @@ export const Clusters = () => {
               onChange={(e) => {
                 const model: ClusterModel = {
                   ...editClusterModel,
-                  acceptableUsePolicyUrl: e.target.value,
+                  acceptableUsePolicyUrl:
+                    e.target.value === "" ? undefined : e.target.value, // server-side validation doesn't like empty strings
                 };
                 setEditClusterModel(model);
                 setReturn(model);

--- a/Hippo.Web/ClientApp/src/components/ClusterAdmin/Clusters.tsx
+++ b/Hippo.Web/ClientApp/src/components/ClusterAdmin/Clusters.tsx
@@ -180,6 +180,47 @@ export const Clusters = () => {
               id="selectAccessTypes"
             />
           </div>
+          <div className="form-group">
+            <label className="form-label" htmlFor="fieldAcceptableUsePolicyUrl">
+              Acceptable Use Policy URL
+            </label>
+            <input
+              className="form-control"
+              id="fieldAcceptableUsePolicyUrl"
+              value={editClusterModel.acceptableUsePolicyUrl}
+              onChange={(e) => {
+                const model: ClusterModel = {
+                  ...editClusterModel,
+                  acceptableUsePolicyUrl: e.target.value,
+                };
+                setEditClusterModel(model);
+                setReturn(model);
+              }}
+            />
+          </div>
+          <div className="form-group">
+            <label htmlFor="fieldAcceptableUsePolicyUpdatedOn">
+              Acceptable Use Policy Updated On
+            </label>
+            <input
+              type="date"
+              className="form-control"
+              id="fieldAcceptableUsePolicyUpdatedOn"
+              value={
+                editClusterModel.acceptableUsePolicyUpdatedOn
+                  ? editClusterModel.acceptableUsePolicyUpdatedOn.split("T")[0]
+                  : ""
+              }
+              onChange={(e) => {
+                const model: ClusterModel = {
+                  ...editClusterModel,
+                  acceptableUsePolicyUpdatedOn: e.target.value,
+                };
+                setEditClusterModel(model);
+                setReturn(model);
+              }}
+            />
+          </div>
         </>
       ),
       canConfirm:
@@ -266,6 +307,33 @@ export const Clusters = () => {
               disabled={true}
               placeHolder="none selected"
               id="selectedAccessTypes"
+            />
+          </div>
+          <div className="form-group">
+            <label className="form-label" htmlFor="fieldAcceptableUsePolicyUrl">
+              Acceptable Use Policy URL
+            </label>
+            <input
+              className="form-control"
+              id="fieldAcceptableUsePolicyUrl"
+              value={editClusterModel.acceptableUsePolicyUrl}
+              readOnly
+            />
+          </div>
+          <div className="form-group">
+            <label htmlFor="fieldAcceptableUsePolicyUpdatedOn">
+              Acceptable Use Policy Updated On
+            </label>
+            <input
+              type="date"
+              className="form-control"
+              id="fieldAcceptableUsePolicyUpdatedOn"
+              value={
+                editClusterModel.acceptableUsePolicyUpdatedOn
+                  ? editClusterModel.acceptableUsePolicyUpdatedOn.split("T")[0]
+                  : ""
+              }
+              readOnly
             />
           </div>
         </>

--- a/Hippo.Web/ClientApp/src/components/ClusterAdmin/Clusters.tsx
+++ b/Hippo.Web/ClientApp/src/components/ClusterAdmin/Clusters.tsx
@@ -213,9 +213,11 @@ export const Clusters = () => {
                   : ""
               }
               onChange={(e) => {
+                const newValue = e.target.value;
                 const model: ClusterModel = {
                   ...editClusterModel,
-                  acceptableUsePolicyUpdatedOn: e.target.value,
+                  acceptableUsePolicyUpdatedOn:
+                    newValue === "" ? undefined : newValue,
                 };
                 setEditClusterModel(model);
                 setReturn(model);

--- a/Hippo.Web/ClientApp/src/test/mockData.ts
+++ b/Hippo.Web/ClientApp/src/test/mockData.ts
@@ -62,6 +62,9 @@ export const fakeAccounts: AccountModel[] = [
     accessTypes: ["OpenOnDemand", "SshKey"],
     data: {} as PuppetUserRecord,
     tags: [],
+    acceptableUsePolicyAgreedOn: new Date(
+      new Date().setHours(0, 0, 0, 0),
+    ).toISOString(),
   },
   {
     id: 2,
@@ -76,6 +79,9 @@ export const fakeAccounts: AccountModel[] = [
     accessTypes: ["OpenOnDemand", "SshKey"],
     data: {} as PuppetUserRecord,
     tags: [],
+    acceptableUsePolicyAgreedOn: new Date(
+      new Date().setHours(0, 0, 0, 0),
+    ).toISOString(),
   },
 ];
 
@@ -119,6 +125,10 @@ const fakeCluster: ClusterModel = {
   email: "an-email@address.com",
   accessTypes: ["OpenOnDemand", "SshKey"],
   allowOrders: false,
+  acceptableUsePolicyUrl: "https://aup-for-some-cluster.com",
+  acceptableUsePolicyUpdatedOn: new Date(
+    new Date().setMonth(new Date().getMonth() - 1),
+  ).toISOString(),
 };
 
 export const fakeAppContext: AppContextShape = {
@@ -156,6 +166,8 @@ export const fakeGroupAdminAppContext: AppContextShape = {
   clusters: [fakeCluster],
   openRequests: fakeRequests,
 };
+
+export const fakeSetContext = vi.fn();
 
 export const fakeAdminUsers: User[] = [
   fakeAdminUser,

--- a/Hippo.Web/ClientApp/src/types.ts
+++ b/Hippo.Web/ClientApp/src/types.ts
@@ -52,6 +52,7 @@ export enum RequestStatus {
 
 // action-specific RequestModel fields defined here...
 export interface AccountRequestDataModel {
+  acceptableUsePolicyAgreedOn?: string;
   supervisingPI: string;
   sshKey?: string;
   accessTypes: AccessType[];
@@ -89,6 +90,7 @@ export interface AccountModel {
   accessTypes: AccessType[];
   data: PuppetUserRecord;
   tags: string[];
+  acceptableUsePolicyAgreedOn?: string;
 }
 
 export interface AccountTagsModel {
@@ -97,6 +99,7 @@ export interface AccountTagsModel {
 }
 
 export interface AccountCreateModel {
+  acceptableUsePolicyAgreedOn?: string;
   groupId: number;
   sshKey: string;
   supervisingPI: string;
@@ -142,6 +145,8 @@ export interface ClusterModel {
   accessTypes: AccessType[];
   sshKey?: string;
   allowOrders: boolean;
+  acceptableUsePolicyUrl?: string;
+  acceptableUsePolicyUpdatedOn?: string;
 }
 
 export type ModelState = Record<string, string>;

--- a/Hippo.Web/Controllers/AccountController.cs
+++ b/Hippo.Web/Controllers/AccountController.cs
@@ -202,6 +202,7 @@ public class AccountController : SuperController
         }
         .WithAccountRequestData(new AccountRequestDataModel
         {
+            AcceptableUsePolicyAgreedOn = model.AcceptableUsePolicyAgreedOn,
             SupervisingPI = model.SupervisingPI,
             SshKey = model.SshKey,
             AccessTypes = model.AccessTypes

--- a/Hippo.Web/Controllers/ClusterAdminController.cs
+++ b/Hippo.Web/Controllers/ClusterAdminController.cs
@@ -136,6 +136,9 @@ namespace Hippo.Web.Controllers
             cluster.Description = clusterModel.Description;
             cluster.Email = clusterModel.Email;
 
+            cluster.AcceptableUsePolicyUrl = clusterModel.AcceptableUsePolicyUrl;
+            cluster.AcceptableUsePolicyUpdatedOn = clusterModel.AcceptableUsePolicyUpdatedOn;
+
             _dbContext.Clusters.Update(cluster);
             await _dbContext.SaveChangesAsync();
 

--- a/Hippo.Web/Models/AccountCreateModel.cs
+++ b/Hippo.Web/Models/AccountCreateModel.cs
@@ -6,6 +6,7 @@ namespace Hippo.Web.Models
 {
     public class AccountCreateModel
     {
+        public DateTime? AcceptableUsePolicyAgreedOn { get; set; }
         public int GroupId { get; set; }
         public string SshKey { get; set; } = String.Empty;
         [MaxLength(100)]

--- a/Hippo.Web/Models/AccountModel.cs
+++ b/Hippo.Web/Models/AccountModel.cs
@@ -20,6 +20,7 @@ namespace Hippo.Web.Models
         public DateTime UpdatedOn { get; set; }
         public JsonElement? Data { get; set; }
         public List<string> Tags { get; set; } = new();
+        public DateTime? AcceptableUsePolicyAgreedOn { get; set; }
 
         public AccountModel()
         {
@@ -35,6 +36,7 @@ namespace Hippo.Web.Models
             CreatedOn = account.CreatedOn;
             Cluster = account.Cluster.Name;
             Owner = account.Owner;
+            AcceptableUsePolicyAgreedOn = account.AcceptableUsePolicyAgreedOn;
             MemberOfGroups = account.MemberOfGroups.Select(g => new GroupModel
             {
                 Id = g.Id,
@@ -82,6 +84,7 @@ namespace Hippo.Web.Models
                 CreatedOn = a.CreatedOn,
                 Cluster = a.Cluster.Name,
                 Owner = a.Owner,
+                AcceptableUsePolicyAgreedOn = a.AcceptableUsePolicyAgreedOn,
                 MemberOfGroups = a.MemberOfGroups.Select(g => new GroupModel
                 {
                     Id = g.Id,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/2d471cd9-904b-4898-9a3d-9ec282ccf486)


If an existing account's AUP agreement date doesn't exist or is expired, the user will be presented with the following on all applicable routes...

![image](https://github.com/user-attachments/assets/8d94991c-0b45-43ba-a79e-cb9140d484ea)

The cluster edit form...

![image](https://github.com/user-attachments/assets/46b33418-8c8b-411d-bd6c-df2fc63a216b)

I've only run this against my local db. If you want to run it against test, you'll need to go into the cluster admin page and add a AUP url and date.

If a cluster hasn't configured an AUP, the agreement UI isn't shown, and the user is not blocked.


Closes #513