### PR TITLE
Disable account delete and normalize account.data

### DIFF
--- a/Hippo.Core/Services/AccountSyncService.cs
+++ b/Hippo.Core/Services/AccountSyncService.cs
@@ -90,7 +90,7 @@ namespace Hippo.Core.Services
                     .Where(g => IsValid(g))
                     .ToArray();
 
-                // TODO: reenable accout/group deletions after soft delete refactor
+                // TODO: reenable account/group deletions after soft delete refactor
                 // // Determine what groups and accounts need to be deleted.
                 // // We can't use BulkInsertOrUpdateOrDeleteAsync because operations against GroupMemberAccount and GroupAdminAccount must occur
                 // // between inserts and deletes of groups and accounts.

--- a/Hippo.Core/Utilities/JsonHelper.cs
+++ b/Hippo.Core/Utilities/JsonHelper.cs
@@ -32,4 +32,51 @@ public static class JsonHelper
     {
         return value?.Deserialize<T>(_deserializeOptions);
     }
+
+    /// <summary>
+    /// Ensures consistent formatting of json so that string equality works as long as
+    /// JSON is semantically equivalent
+    /// </summary>
+    public static JsonElement NormalizeJson(JsonElement element)
+    {
+        var node = JsonNode.Parse(element.GetRawText());
+        var normalizedNode = NormalizeNode(node);
+
+        // Convert back to JsonElement by parsing the normalized JSON string
+        using var doc = JsonDocument.Parse(normalizedNode!.ToJsonString(new JsonSerializerOptions
+        {
+            WriteIndented = false,
+            Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+        }));
+
+        // Return a copy of the root element
+        return doc.RootElement.Clone();
+    }
+
+    private static JsonNode NormalizeNode(JsonNode node)
+    {
+        switch (node)
+        {
+            case JsonObject obj:
+                var sorted = new JsonObject();
+                foreach (var kv in obj.OrderBy(kv => kv.Key, StringComparer.Ordinal))
+                {
+                    sorted[kv.Key] = NormalizeNode(kv.Value);
+                }
+                return sorted;
+
+            case JsonArray array:
+                var normalizedArray = new JsonArray();
+                foreach (var item in array)
+                {
+                    normalizedArray.Add(NormalizeNode(item));
+                }
+                return normalizedArray;
+
+            default:
+                return node is not null
+                    ? JsonNode.Parse(node.ToJsonString())
+                    : null;
+        }
+    }
 }


### PR DESCRIPTION
I haven't actually been able to reproduce accounts being updated every day. What I think may be happening is a group with many accounts gets its QOS updated, resulting in every member account getting a corresponding update to its Json Data property, since QOS references are expanded during sync. So the json normalization is probably unnecessary, but it doesn't put much of a dent in performance.

Closes #539