### PR TITLE
Reset returnValue after dialog closes

### DIFF
--- a/Hippo.Web/ClientApp/src/Shared/ConfirmationDialog.tsx
+++ b/Hippo.Web/ClientApp/src/Shared/ConfirmationDialog.tsx
@@ -32,12 +32,16 @@ export const useConfirmationDialog = <T extends any = undefined>(
     resolveRef.current && resolveRef.current([true, returnValue as T]);
     promiseRef.current = undefined;
     resolveRef.current = undefined;
+    // Restore to default state for next use
+    setReturnValue(undefined);
   };
 
   const dismiss = () => {
     resolveRef.current && resolveRef.current([false, undefined as T]);
     promiseRef.current = undefined;
     resolveRef.current = undefined;
+    // Restore to default state for next use
+    setReturnValue(undefined);
   };
 
   const buttons = props.buttons ?? ["Confirm", "Cancel"];

--- a/Hippo.Web/ClientApp/src/Shared/ConfirmationDialog.tsx
+++ b/Hippo.Web/ClientApp/src/Shared/ConfirmationDialog.tsx
@@ -28,20 +28,20 @@ export const useConfirmationDialog = <T extends any = undefined>(
   const resolveRef = useRef<(value: [boolean, T]) => void>();
   const [returnValue, setReturnValue] = useState<T>();
 
-  const confirm = () => {
-    resolveRef.current && resolveRef.current([true, returnValue as T]);
+  const resetState = () => {
     promiseRef.current = undefined;
     resolveRef.current = undefined;
-    // Restore to default state for next use
     setReturnValue(undefined);
+  };
+
+  const confirm = () => {
+    resolveRef.current && resolveRef.current([true, returnValue as T]);
+    resetState();
   };
 
   const dismiss = () => {
     resolveRef.current && resolveRef.current([false, undefined as T]);
-    promiseRef.current = undefined;
-    resolveRef.current = undefined;
-    // Restore to default state for next use
-    setReturnValue(undefined);
+    resetState();
   };
 
   const buttons = props.buttons ?? ["Confirm", "Cancel"];


### PR DESCRIPTION
It wasn't the the return value of the canConfirm function that was the problem. It was the fact that the hook maintains returnValue state across dialog invocations. It now clears that state on each confirmation/dismissal.

Closes #572 