### PR TITLE
Fix group permissions for cluster admins

### DIFF
--- a/Hippo.Web/ClientApp/src/App.tsx
+++ b/Hippo.Web/ClientApp/src/App.tsx
@@ -76,7 +76,7 @@ const App = () => {
             <Route
               path="/:cluster/approve"
               element={
-                <ShowFor roles={["GroupAdmin"]} alternative={<NotAuthorized />}>
+                <ShowFor roles={["GroupAdmin", "ClusterAdmin"]} alternative={<NotAuthorized />}>
                   <RequireAupAgreement>
                     <Requests />
                   </RequireAupAgreement>
@@ -86,7 +86,7 @@ const App = () => {
             <Route
               path="/:cluster/activeaccounts"
               element={
-                <ShowFor roles={["GroupAdmin"]} alternative={<NotAuthorized />}>
+                <ShowFor roles={["GroupAdmin", "ClusterAdmin"]} alternative={<NotAuthorized />}>
                   <RequireAupAgreement>
                     <ActiveAccounts />
                   </RequireAupAgreement>

--- a/Hippo.Web/ClientApp/src/AppNav.tsx
+++ b/Hippo.Web/ClientApp/src/AppNav.tsx
@@ -86,7 +86,7 @@ export const AppNav = () => {
                     Admin
                   </DropdownToggle>
                   <DropdownMenu>
-                    <ShowFor roles={["GroupAdmin"]}>
+                    <ShowFor roles={["GroupAdmin", "ClusterAdmin"]}>
                       <DropdownItem>
                         <NavLink
                           id="sponsorApprove"
@@ -100,7 +100,7 @@ export const AppNav = () => {
                         </NavLink>
                       </DropdownItem>
                     </ShowFor>
-                    <ShowFor roles={["GroupAdmin"]}>
+                    <ShowFor roles={["GroupAdmin", "ClusterAdmin"]}>
                       <DropdownItem>
                         <NavLink
                           id="activeAccounts"

--- a/Hippo.Web/ClientApp/src/Shared/requestUtils.ts
+++ b/Hippo.Web/ClientApp/src/Shared/requestUtils.ts
@@ -14,3 +14,7 @@ export const getGroupModelFromRequest = (r: RequestModel) => {
       } as GroupModel)
     : r.groupModel;
 };
+
+export const getGroupNameFromRequest = (r: RequestModel) => {
+  return r.action === "CreateGroup" ? r.data.name : r.groupModel.name;
+};

--- a/Hippo.Web/ClientApp/src/Shared/usePermissions.ts
+++ b/Hippo.Web/ClientApp/src/Shared/usePermissions.ts
@@ -22,7 +22,7 @@ export const usePermissions = () => {
   };
 
   const canManageGroup = (groupName: string) => {
-    if (isSystemAdmin || isClusterAdmin) return true;
+    if (isSystemAdmin) return true;
     if (!clusterName) return false;
     const account = accounts.find((a) => a.cluster === clusterName);
     if (!account) return false;

--- a/Hippo.Web/ClientApp/src/components/Account/Requests.tsx
+++ b/Hippo.Web/ClientApp/src/components/Account/Requests.tsx
@@ -14,8 +14,9 @@ import HipMainWrapper from "../../Shared/Layout/HipMainWrapper";
 import HipTitle from "../../Shared/Layout/HipTitle";
 import HipBody from "../../Shared/Layout/HipBody";
 import HipLoading from "../../Shared/LoadingAndErrors/HipLoading";
-import { getGroupModelFromRequest } from "../../Shared/requestUtils";
+import { getGroupModelFromRequest, getGroupNameFromRequest } from "../../Shared/requestUtils";
 import AppContext from "../../Shared/AppContext";
+import { usePermissions } from "../../Shared/usePermissions";
 
 export const Requests = () => {
   // get all accounts that need approval and list them
@@ -78,6 +79,8 @@ export const Requests = () => {
     },
     [requests],
   );
+
+  const { canManageGroup } = usePermissions()
 
   const columnHelper = createColumnHelper<RequestModel>();
 
@@ -174,27 +177,33 @@ export const Requests = () => {
     columnHelper.display({
       id: "actions",
       header: "Action",
-      cell: (props) => (
-        <>
-          <HipButton
-            id="approveButton"
-            disabled={notification.pending}
-            onClick={() => handleApprove(props.row.original)}
-          >
-            {requestApproving === props.row.original.id
-              ? "Approving..."
-              : "Approve"}
-          </HipButton>
-          {requestApproving !== props.row.original.id && (
-            <RejectRequest
-              request={props.row.original}
-              removeAccount={() => handleReject(props.row.original)}
-              updateUrl={`/api/${clusterName}/request/reject/`}
+      cell: (props) => {
+        const groupName = getGroupNameFromRequest(props.row.original);
+        if (!canManageGroup(groupName)) {
+          return <></>; // user cannot approve or reject this request>;
+        }
+        return (
+          <>
+            <HipButton
+              id="approveButton"
               disabled={notification.pending}
-            ></RejectRequest>
-          )}
-        </>
-      ),
+              onClick={() => handleApprove(props.row.original)}
+            >
+              {requestApproving === props.row.original.id
+                ? "Approving..."
+                : "Approve"}
+            </HipButton>
+            {requestApproving !== props.row.original.id && (
+              <RejectRequest
+                request={props.row.original}
+                removeAccount={() => handleReject(props.row.original)}
+                updateUrl={`/api/${clusterName}/request/reject/`}
+                disabled={notification.pending}
+              ></RejectRequest>
+            )}
+          </>
+        );
+      },
     }),
   );
 

--- a/Hippo.Web/ClientApp/src/components/Group/GroupInfo.tsx
+++ b/Hippo.Web/ClientApp/src/components/Group/GroupInfo.tsx
@@ -53,7 +53,7 @@ export const GroupInfo = ({
         </Button>
       </ShowFor>
       <ShowFor
-        condition={() => !!navigateToGroupMembers && canManageGroup(group.name)}
+        condition={() => !!navigateToGroupMembers && canViewGroup(group.name)}
       >
         {" - "}
         <Button size="sm" color="link" onClick={handleShowMembers}>

--- a/Hippo.Web/ClientApp/src/test/mockData.ts
+++ b/Hippo.Web/ClientApp/src/test/mockData.ts
@@ -9,6 +9,7 @@ import {
   RequestModel,
   AccountRequestDataModel,
   RequestStatus,
+  GroupAccountModel
 } from "../types";
 
 const fakeUser: User = {
@@ -21,7 +22,7 @@ const fakeUser: User = {
   name: "Mr Mr Mr Bob Dobalina",
 };
 
-const fakeAdminUser: User = {
+const fakeGroupAdminUser: User = {
   id: 1,
   firstName: "Bob",
   lastName: "Dobalina",
@@ -31,19 +32,38 @@ const fakeAdminUser: User = {
   name: "Mr Mr Mr Bob Dobalina",
 };
 
+export const fakeAdminUsers: User[] = [
+  fakeGroupAdminUser,
+  {
+    id: 4,
+    firstName: "Bobby",
+    lastName: "Dob",
+    email: "bdob@ucdavis.edu",
+    iam: "1000037199",
+    kerberos: "bdob",
+    name: "A Fake Admin User",
+  },
+];
+
+const fakeAdminGroupAccount: GroupAccountModel = {
+  name: fakeGroupAdminUser.kerberos,
+  email: fakeGroupAdminUser.email,
+  kerberos: fakeGroupAdminUser.kerberos,
+};
+
 export const fakeGroups: GroupModel[] = [
   {
     id: 1,
     name: "group1",
     displayName: "Group 1",
-    admins: [],
+    admins: [fakeAdminGroupAccount],
     data: {} as PuppetGroupRecord,
   },
   {
     id: 2,
     name: "group2",
     displayName: "Group 2",
-    admins: [],
+    admins: [fakeAdminGroupAccount],
     data: {} as PuppetGroupRecord,
   },
 ];
@@ -84,6 +104,27 @@ export const fakeAccounts: AccountModel[] = [
     ).toISOString(),
   },
 ];
+
+export const fakeGroupAdminAccounts: AccountModel[] = [
+  {
+    id: 3,
+    name: "Account 1",
+    email: fakeUser.email,
+    kerberos: fakeUser.kerberos,
+    cluster: "caesfarm",
+    createdOn: "2020-01-01T00:00:00.000Z",
+    updatedOn: "2020-01-01T00:00:00.000Z",
+    memberOfGroups: [...fakeGroups],
+    adminOfGroups: [...fakeGroups],
+    accessTypes: ["OpenOnDemand", "SshKey"],
+    data: {} as PuppetUserRecord,
+    tags: [],
+    acceptableUsePolicyAgreedOn: new Date(
+      new Date().setHours(0, 0, 0, 0),
+    ).toISOString(),
+  },
+];
+
 
 export const fakeRequests: RequestModel[] = [
   {
@@ -160,7 +201,7 @@ export const fakeGroupAdminAppContext: AppContextShape = {
   antiForgeryToken: "fakeAntiForgeryToken",
   user: {
     detail: {
-      ...fakeAdminUser,
+      ...fakeGroupAdminUser,
     },
     permissions: [
       {
@@ -169,7 +210,7 @@ export const fakeGroupAdminAppContext: AppContextShape = {
       },
     ],
   },
-  accounts: [fakeAccounts[0]],
+  accounts: [fakeGroupAdminAccounts[0]],
   clusters: [fakeCluster],
   openRequests: fakeRequests,
   featureFlags: fakeFeatureFlags,
@@ -177,18 +218,6 @@ export const fakeGroupAdminAppContext: AppContextShape = {
 
 export const fakeSetContext = vi.fn();
 
-export const fakeAdminUsers: User[] = [
-  fakeAdminUser,
-  {
-    id: 4,
-    firstName: "Bobby",
-    lastName: "Dob",
-    email: "bdob@ucdavis.edu",
-    iam: "1000037199",
-    kerberos: "bdob",
-    name: "A Fake Admin User",
-  },
-];
 
 export const fakeAppContextNoAccount: AppContextShape = {
   antiForgeryToken: "fakeAntiForgeryToken",


### PR DESCRIPTION
Cluster admins can now see Requests and Accounts, while only Group admins can approve/reject Requests for their group.

Closes #590