### PR TITLE
Require supervising PI for genome-center-grp access requests

### DIFF
--- a/Hippo.Web/ClientApp/src/components/Account/AccountInfo.test.tsx
+++ b/Hippo.Web/ClientApp/src/components/Account/AccountInfo.test.tsx
@@ -1,0 +1,202 @@
+import { act } from "react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { ModalProvider } from "react-modal-hook";
+import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import userEvent from "@testing-library/user-event";
+import AppContext from "../../Shared/AppContext";
+import { responseMap } from "../../test/testHelpers";
+import {
+  fakeAppContext,
+  fakeSetContext,
+  fakeFeatureFlags,
+} from "../../test/mockData";
+import { GroupModel, PuppetGroupRecord, User } from "../../types";
+import { AccountInfo } from "./AccountInfo";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock("../Group/GroupLookup", () => ({
+  GroupLookup: ({
+    options,
+    setSelection,
+  }: {
+    options: GroupModel[];
+    setSelection: (selection?: GroupModel) => void;
+  }) => (
+    <div>
+      {options.map((group) => (
+        <button
+          key={group.id}
+          type="button"
+          onClick={() => setSelection(group)}
+        >
+          {`Select ${group.name}`}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+const fakePI: User = {
+  id: 42,
+  firstName: "Gene",
+  lastName: "Principal",
+  email: "gene.pi@ucdavis.edu",
+  iam: "1000000042",
+  kerberos: "genepi",
+  name: "Gene Principal",
+};
+
+vi.mock("../../Shared/SearchPerson", () => ({
+  SearchPerson: ({
+    onChange,
+  }: {
+    onChange: (user: User | undefined) => void;
+  }) => (
+    <div>
+      <button type="button" onClick={() => onChange(fakePI)}>
+        Select PI
+      </button>
+      <button type="button" onClick={() => onChange(undefined)}>
+        Clear PI
+      </button>
+    </div>
+  ),
+}));
+
+const accountInfoContext = {
+  ...fakeAppContext,
+  accounts: [
+    {
+      ...fakeAppContext.accounts[0],
+      memberOfGroups: [],
+      adminOfGroups: [],
+    },
+  ],
+  openRequests: [],
+  featureFlags: fakeFeatureFlags,
+};
+
+const testCluster = accountInfoContext.accounts[0].cluster;
+const myAccountUrl = `/${testCluster}/myaccount`;
+const fakeGroups: GroupModel[] = [
+  {
+    id: 101,
+    name: "genome-center-grp",
+    displayName: "Genome Center",
+    admins: [],
+    data: {} as PuppetGroupRecord,
+  },
+  {
+    id: 102,
+    name: "regular-group",
+    displayName: "Regular Group",
+    admins: [],
+    data: {} as PuppetGroupRecord,
+  },
+];
+
+const renderAccountInfo = async () => {
+  await act(async () => {
+    render(
+      <AppContext.Provider
+        value={[
+          {
+            ...accountInfoContext,
+          },
+          fakeSetContext,
+        ]}
+      >
+        <MemoryRouter initialEntries={[myAccountUrl]}>
+          <ModalProvider>
+            <Routes>
+              <Route path="/:cluster/myaccount" element={<AccountInfo />} />
+            </Routes>
+          </ModalProvider>
+        </MemoryRouter>
+      </AppContext.Provider>,
+    );
+  });
+};
+
+beforeEach(() => {
+  (global as any).Hippo = accountInfoContext;
+
+  const groupsResponse = Promise.resolve({
+    status: 200,
+    ok: true,
+    json: () => Promise.resolve(fakeGroups),
+  });
+
+  global.fetch = vitest
+    .fn((url, options) => {
+      const absoluteUrl = new URL(url, "http://localhost");
+      return fetch(absoluteUrl.toString(), options);
+    })
+    .mockImplementation((x) =>
+      responseMap(x, {
+        [`/api/${testCluster}/group/groups`]: groupsResponse,
+      }),
+    );
+});
+
+afterEach(() => {
+  if ((global.fetch as any).mockClear) {
+    (global.fetch as any).mockClear();
+  }
+});
+
+it("requires a supervising PI before confirming genome center access", async () => {
+  const user = userEvent.setup();
+  await renderAccountInfo();
+
+  const openModalButton = await screen.findByRole("button", {
+    name: "Request Access to Another Group",
+  });
+
+  await waitFor(() => expect(openModalButton).toBeEnabled());
+
+  await act(async () => {
+    await user.click(openModalButton);
+  });
+
+  const confirmButton = await screen.findByRole("button", { name: "Confirm" });
+  expect(confirmButton).toBeDisabled();
+
+  await act(async () => {
+    await user.click(screen.getByRole("button", { name: "Select genome-center-grp" }));
+  });
+
+  expect(confirmButton).toBeDisabled();
+
+  await act(async () => {
+    await user.click(screen.getByRole("button", { name: "Select PI" }));
+  });
+
+  expect(confirmButton).toBeEnabled();
+});
+
+it("allows confirming a regular group request without selecting a supervising PI", async () => {
+  const user = userEvent.setup();
+  await renderAccountInfo();
+
+  const openModalButton = await screen.findByRole("button", {
+    name: "Request Access to Another Group",
+  });
+
+  await waitFor(() => expect(openModalButton).toBeEnabled());
+
+  await act(async () => {
+    await user.click(openModalButton);
+  });
+
+  const confirmButton = await screen.findByRole("button", { name: "Confirm" });
+  expect(confirmButton).toBeDisabled();
+
+  await act(async () => {
+    await user.click(screen.getByRole("button", { name: "Select regular-group" }));
+  });
+
+  expect(confirmButton).toBeEnabled();
+});

--- a/Hippo.Web/ClientApp/src/components/Account/AccountInfo.tsx
+++ b/Hippo.Web/ClientApp/src/components/Account/AccountInfo.tsx
@@ -25,6 +25,8 @@ import HipButton from "../../Shared/HipComponents/HipButton";
 import { getGroupModelFromRequest } from "../../Shared/requestUtils";
 import { SearchPerson } from "../../Shared/SearchPerson";
 
+const supervisingPIRequiredGroupName = "genome-center-grp";
+
 export const AccountInfo = () => {
   const [notification, setNotification] = usePromiseNotification();
   const [context, setContext] = useContext(AppContext);
@@ -69,6 +71,15 @@ export const AccountInfo = () => {
     fetchGroups();
   }, [adminOfGroups, clusterName, currentOpenRequests, memberOfGroups]);
 
+  const isSupervisingPIRequiredForGroupAccess = useCallback(
+    (groupId?: number) =>
+      availableGroups.some(
+        (group) =>
+          group.id === groupId && group.name === supervisingPIRequiredGroupName,
+      ),
+    [availableGroups],
+  );
+
   const [getGroupAccessConfirmation] = useConfirmationDialog<AddToGroupModel>(
     {
       title: "Request Access to Group",
@@ -109,9 +120,12 @@ export const AccountInfo = () => {
           </div>
         );
       },
-      canConfirm: (returnValue) => returnValue !== undefined,
+      canConfirm: (returnValue) =>
+        !!returnValue?.groupId &&
+        (!isSupervisingPIRequiredForGroupAccess(returnValue.groupId) ||
+          notEmptyOrFalsey(returnValue.supervisingPIIamId)),
     },
-    [availableGroups, supervisingPI],
+    [availableGroups, supervisingPI, isSupervisingPIRequiredForGroupAccess],
   );
 
   const [getGroupCreationConfirmation] =

--- a/Hippo.Web/Controllers/GroupController.cs
+++ b/Hippo.Web/Controllers/GroupController.cs
@@ -20,6 +20,8 @@ namespace Hippo.Web.Controllers;
 [Authorize]
 public class GroupController : SuperController
 {
+    private const string SupervisingPIRequiredGroupName = "genome-center-grp";
+
     private readonly AppDbContext _dbContext;
     private readonly IUserService _userService;
     private readonly INotificationService _notificationService;
@@ -114,6 +116,12 @@ public class GroupController : SuperController
             return BadRequest($"Group does not exist.");
         }
 
+        if (group.Name == SupervisingPIRequiredGroupName
+            && string.IsNullOrWhiteSpace(addToGroupModel.SupervisingPIIamId))
+        {
+            return BadRequest("Please select a supervising PI for this group.");
+        }
+
         var currentAccount = await _dbContext.Accounts
             .AsNoTracking()
             .SingleOrDefaultAsync(a =>
@@ -148,6 +156,7 @@ public class GroupController : SuperController
 
         // Get user Id of the Supervising PI
         int? supervisingPIUserId = null;
+        var supervisingPI = addToGroupModel.SupervisingPI;
         if (!string.IsNullOrWhiteSpace(addToGroupModel.SupervisingPIIamId))
         {
             var user = await _userService.GetUserByIam(addToGroupModel.SupervisingPIIamId);
@@ -157,6 +166,7 @@ public class GroupController : SuperController
                 return BadRequest("Supervising PI not found");
             }
             supervisingPIUserId = user.Id;
+            supervisingPI = user.Name;
         }
 
         var request = new HippoRequest
@@ -171,7 +181,7 @@ public class GroupController : SuperController
         }
         .WithAccountRequestData(new AccountRequestDataModel
         {
-            SupervisingPI = addToGroupModel.SupervisingPI,
+            SupervisingPI = supervisingPI,
             SupervisingPIUserId = supervisingPIUserId
         });
 


### PR DESCRIPTION
When users request access to `genome-center-grp`, Hippo now requires a supervising PI and keeps the modal confirm button disabled until one is selected.

This is a very basic hardcoded implementation to make GC staff's lives easier. For `genome-center-grp`, it is not obvious what lab a user is in the way it usually is when they request access to an individual lab account.

Validation:
- `./node_modules/.bin/vitest run src/components/Account/AccountInfo.test.tsx`
- `npx npm@10.9.2 run build`
- `dotnet build hippo.sln`
