### PR TITLE
Fix group membership sync and make it a bit more testable

### DIFF
--- a/Hippo.Core/Properties/AssemblyInfo.cs
+++ b/Hippo.Core/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Test")]

--- a/Hippo.Core/Services/AccountSyncService.cs
+++ b/Hippo.Core/Services/AccountSyncService.cs
@@ -166,45 +166,25 @@ namespace Hippo.Core.Services
                     .ToDictionaryAsync(a => (a.ClusterId, a.Kerberos), a => a.Id);
 
                 // setup desired state of group memberships
-                var desiredGroupAccounts = mapClusterIdsToPuppetData
-                    .SelectMany(x => x.Value.PuppetData.Users
-                        .Where(u => mapClusterIdAndKerberosToAccountId.ContainsKey((x.Key, u.Kerberos)))
-                        .SelectMany(u => u.Groups.Select(g => new GroupMemberAccount
-                        {
-                            GroupId = mapClusterIdAndGroupNameToId[(x.Key, g)],
-                            AccountId = mapClusterIdAndKerberosToAccountId[(x.Key, u.Kerberos)],
-                            RevokedOn = null
-                        })));
+                var desiredGroupAccounts = AccountSyncPlanner.GetDesiredGroupMemberAccounts(
+                    mapClusterIdsToPuppetData.ToDictionary(x => x.Key, x => x.Value.PuppetData),
+                    mapClusterIdAndGroupNameToId,
+                    mapClusterIdAndKerberosToAccountId);
                 // identify group memberships that need to be soft-deleted
-                var mapClusterIdAndKerberosToUserExists = mapClusterIdsToPuppetData
-                    .SelectMany(x => x.Value.PuppetData.Users.Select(u => (x.Key, u.Kerberos)))
-                    .ToHashSet();
-                var deleteGroupAccounts = (await _dbContext.GroupMemberAccount
+                var activeGroupMemberAccounts = await _dbContext.GroupMemberAccount
                     .AsNoTracking()
                     .IgnoreQueryFilters()
                     .Where(gma => gma.RevokedOn == null)
-                    .Select(gma => new
-                    {
+                    .Select(gma => new GroupMemberAccountSyncState(
                         gma.GroupId,
                         gma.AccountId,
-                        gma.Group.ClusterId,
-                        gma.Account.Kerberos
-                    })
-                    .ToListAsync()) // Some filtering done locally to avoid a sending too many parameters to db
-                    .Where(gma => !mapClusterIdAndKerberosToUserExists.Contains((gma.ClusterId, gma.Kerberos)))
-                    .Select(gma => new GroupMemberAccount
-                    {
-                        GroupId = gma.GroupId,
-                        AccountId = gma.AccountId,
-                        RevokedOn = now
-                    })
-                    .ToList();
-                desiredGroupAccounts = desiredGroupAccounts
-                    // ensure we don't have any duplicates
-                    .Where(gma => !deleteGroupAccounts.Any(dgma => dgma.GroupId == gma.GroupId && dgma.AccountId == gma.AccountId))
-                    .Concat(deleteGroupAccounts)
-                    .ToList();
-
+                        gma.Group.ClusterId))
+                    .ToListAsync();
+                desiredGroupAccounts = AccountSyncPlanner.ApplyRevokedGroupMemberAccounts(
+                    desiredGroupAccounts,
+                    activeGroupMemberAccounts,
+                    mapClusterIdsToPuppetData.Keys,
+                    now);
 
                 var desiredGroupAdminAccounts = mapClusterIdsToPuppetData
                     .SelectMany(x => x.Value.PuppetData.Users
@@ -336,6 +316,61 @@ namespace Hippo.Core.Services
             public int ClusterId { get; set; }
             public PuppetData PuppetData { get; set; }
             public ConcurrentDictionary<string, JsonNode> MapQosStringToQosObject { get; set; } = new();
+        }
+    }
+
+    internal record GroupMemberAccountSyncState(int GroupId, int AccountId, int ClusterId);
+
+    internal static class AccountSyncPlanner
+    {
+        public static List<GroupMemberAccount> GetDesiredGroupMemberAccounts(
+            IReadOnlyDictionary<int, PuppetData> puppetDataByClusterId,
+            IReadOnlyDictionary<(int ClusterId, string GroupName), int> groupIds,
+            IReadOnlyDictionary<(int ClusterId, string Kerberos), int> accountIds)
+        {
+            return puppetDataByClusterId
+                .SelectMany(x => x.Value.Users
+                    .Where(u => accountIds.ContainsKey((x.Key, u.Kerberos)))
+                    .SelectMany(u => u.Groups.Select(g => new GroupMemberAccount
+                    {
+                        GroupId = groupIds[(x.Key, g)],
+                        AccountId = accountIds[(x.Key, u.Kerberos)],
+                        RevokedOn = null
+                    })))
+                .ToList();
+        }
+
+        public static List<GroupMemberAccount> ApplyRevokedGroupMemberAccounts(
+            IEnumerable<GroupMemberAccount> desiredGroupAccounts,
+            IEnumerable<GroupMemberAccountSyncState> activeGroupMemberAccounts,
+            IEnumerable<int> syncedClusterIds,
+            DateTime revokedOn)
+        {
+            var desiredGroupAccountsList = desiredGroupAccounts.ToList();
+            var desiredGroupAccountKeys = desiredGroupAccountsList
+                .Select(gma => (gma.GroupId, gma.AccountId))
+                .ToHashSet();
+            var syncedClusterIdsSet = syncedClusterIds.ToHashSet();
+
+            var deleteGroupAccounts = activeGroupMemberAccounts
+                .Where(gma => syncedClusterIdsSet.Contains(gma.ClusterId) &&
+                    !desiredGroupAccountKeys.Contains((gma.GroupId, gma.AccountId)))
+                .Select(gma => new GroupMemberAccount
+                {
+                    GroupId = gma.GroupId,
+                    AccountId = gma.AccountId,
+                    RevokedOn = revokedOn
+                })
+                .ToList();
+            var deleteGroupAccountKeys = deleteGroupAccounts
+                .Select(gma => (gma.GroupId, gma.AccountId))
+                .ToHashSet();
+
+            return desiredGroupAccountsList
+                // ensure we don't have any duplicates
+                .Where(gma => !deleteGroupAccountKeys.Contains((gma.GroupId, gma.AccountId)))
+                .Concat(deleteGroupAccounts)
+                .ToList();
         }
     }
 }

--- a/Test/AccountSyncPlannerTests.cs
+++ b/Test/AccountSyncPlannerTests.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Hippo.Core.Domain;
+using Hippo.Core.Services;
+using Shouldly;
+using Xunit;
+
+namespace Test
+{
+    public class AccountSyncPlannerTests
+    {
+        [Fact]
+        public void GetDesiredGroupMemberAccounts_CreatesMembershipsForUserGroups()
+        {
+            var puppetDataByClusterId = new Dictionary<int, PuppetData>
+            {
+                [1] = new()
+                {
+                    Users =
+                    {
+                        new PuppetUser
+                        {
+                            Kerberos = "kerb1",
+                            Groups = new[] { "group-a", "group-b" }
+                        },
+                        new PuppetUser
+                        {
+                            Kerberos = "not-yet-in-db",
+                            Groups = new[] { "group-a" }
+                        }
+                    }
+                }
+            };
+            var groupIds = new Dictionary<(int ClusterId, string GroupName), int>
+            {
+                [(1, "group-a")] = 10,
+                [(1, "group-b")] = 11
+            };
+            var accountIds = new Dictionary<(int ClusterId, string Kerberos), int>
+            {
+                [(1, "kerb1")] = 100
+            };
+
+            var desired = AccountSyncPlanner.GetDesiredGroupMemberAccounts(
+                puppetDataByClusterId,
+                groupIds,
+                accountIds);
+
+            desired.Select(gma => (gma.GroupId, gma.AccountId, gma.RevokedOn))
+                .ShouldBe(new[]
+                {
+                    (10, 100, (DateTime?)null),
+                    (11, 100, (DateTime?)null)
+                }, ignoreOrder: true);
+        }
+
+        [Fact]
+        public void ApplyRevokedGroupMemberAccounts_RevokesGroupRemovedFromExistingAccount()
+        {
+            var revokedOn = new DateTime(2026, 5, 7, 12, 0, 0, DateTimeKind.Utc);
+            var desired = new[]
+            {
+                new GroupMemberAccount { GroupId = 10, AccountId = 100, RevokedOn = null }
+            };
+            var activeMemberships = new[]
+            {
+                new GroupMemberAccountSyncState(GroupId: 10, AccountId: 100, ClusterId: 1),
+                new GroupMemberAccountSyncState(GroupId: 11, AccountId: 100, ClusterId: 1)
+            };
+
+            var syncSet = AccountSyncPlanner.ApplyRevokedGroupMemberAccounts(
+                desired,
+                activeMemberships,
+                new[] { 1 },
+                revokedOn);
+
+            syncSet.Count.ShouldBe(2);
+            syncSet.Single(gma => gma.GroupId == 10 && gma.AccountId == 100).RevokedOn.ShouldBeNull();
+            syncSet.Single(gma => gma.GroupId == 11 && gma.AccountId == 100).RevokedOn.ShouldBe(revokedOn);
+        }
+
+        [Fact]
+        public void ApplyRevokedGroupMemberAccounts_RevokesMembershipsForAccountsMissingFromPuppet()
+        {
+            var revokedOn = new DateTime(2026, 5, 7, 12, 0, 0, DateTimeKind.Utc);
+            var activeMemberships = new[]
+            {
+                new GroupMemberAccountSyncState(GroupId: 10, AccountId: 100, ClusterId: 1)
+            };
+
+            var syncSet = AccountSyncPlanner.ApplyRevokedGroupMemberAccounts(
+                Array.Empty<GroupMemberAccount>(),
+                activeMemberships,
+                new[] { 1 },
+                revokedOn);
+
+            var revokedMembership = syncSet.ShouldHaveSingleItem();
+            revokedMembership.GroupId.ShouldBe(10);
+            revokedMembership.AccountId.ShouldBe(100);
+            revokedMembership.RevokedOn.ShouldBe(revokedOn);
+        }
+
+        [Fact]
+        public void ApplyRevokedGroupMemberAccounts_DoesNotRevokeMembershipsOutsideSyncedClusters()
+        {
+            var activeMemberships = new[]
+            {
+                new GroupMemberAccountSyncState(GroupId: 10, AccountId: 100, ClusterId: 2)
+            };
+
+            var syncSet = AccountSyncPlanner.ApplyRevokedGroupMemberAccounts(
+                Array.Empty<GroupMemberAccount>(),
+                activeMemberships,
+                new[] { 1 },
+                DateTime.UtcNow);
+
+            syncSet.ShouldBeEmpty();
+        }
+
+        [Fact]
+        public void ApplyRevokedGroupMemberAccounts_IncludesDesiredMembershipsAsActive()
+        {
+            var desired = new[]
+            {
+                new GroupMemberAccount { GroupId = 10, AccountId = 100, RevokedOn = null }
+            };
+
+            var syncSet = AccountSyncPlanner.ApplyRevokedGroupMemberAccounts(
+                desired,
+                Array.Empty<GroupMemberAccountSyncState>(),
+                new[] { 1 },
+                DateTime.UtcNow);
+
+            var desiredMembership = syncSet.ShouldHaveSingleItem();
+            desiredMembership.GroupId.ShouldBe(10);
+            desiredMembership.AccountId.ShouldBe(100);
+            desiredMembership.RevokedOn.ShouldBeNull();
+        }
+    }
+}


### PR DESCRIPTION
The sync job was revoking group memberships only when the account disappeared from Puppet entirely.

Closes #595 
Closes #611