### PR TITLE
Add an non-CI integration test for KeyVault

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,14 @@ Make sure to invoke "Prettier" before committing JS changes.  If using VSCode co
 
 If making large JS changes, run `npm test` inside the `Hippo.Web/ClientApp` directory and it will automatically re-run affected tests.
 
+## Integration smoke tests
+
+The Key Vault smoke test is opt-in because it writes to the configured Azure Key Vault. It uses the same user-secrets file as `Hippo.Web`, so make sure the `Azure` section is configured before running it.
+
+To verify that Hippo can write, read, and delete a temporary Key Vault secret, run:
+
+```bash
+RUN_KEYVAULT_SMOKE_TESTS=true dotnet test Test/Test.csproj --filter FullyQualifiedName~KeyVaultSmokeTests
+```
+
+Without `RUN_KEYVAULT_SMOKE_TESTS=true`, the test exits without contacting Key Vault.

--- a/Test/KeyVaultSmokeTests.cs
+++ b/Test/KeyVaultSmokeTests.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Threading.Tasks;
+using Hippo.Core.Models.Settings;
+using Hippo.Core.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Test
+{
+    [Trait("Category", "Integration")]
+    public class KeyVaultSmokeTests
+    {
+        private const string RunSmokeTestsEnvironmentVariable = "RUN_KEYVAULT_SMOKE_TESTS";
+
+        private readonly ITestOutputHelper _output;
+
+        public KeyVaultSmokeTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public async Task SecretsService_CanWriteReadAndDeleteAKeyVaultSecret()
+        {
+            if (!string.Equals(
+                    Environment.GetEnvironmentVariable(RunSmokeTestsEnvironmentVariable),
+                    "true",
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                _output.WriteLine(
+                    $"Skipping Key Vault smoke test. Set {RunSmokeTestsEnvironmentVariable}=true to run it.");
+                return;
+            }
+
+            var azureSettings = GetAzureSettingsFromHippoWebUserSecrets();
+            var secretsService = new SecretsService(Options.Create(azureSettings));
+            var secretName = $"hippo-smoke-test-{Guid.NewGuid():N}";
+            var secretValue = $"smoke-test-value-{Guid.NewGuid():N}";
+            var secretWasCreated = false;
+
+            try
+            {
+                await secretsService.SetSecret(secretName, secretValue);
+                secretWasCreated = true;
+
+                var retrievedSecret = await secretsService.GetSecret(secretName);
+
+                retrievedSecret.ShouldBe(secretValue);
+            }
+            finally
+            {
+                if (secretWasCreated)
+                {
+                    await secretsService.DeleteSecret(secretName);
+                }
+            }
+        }
+
+        private static AzureSettings GetAzureSettingsFromHippoWebUserSecrets()
+        {
+            var configuration = new ConfigurationBuilder()
+                .AddUserSecrets<KeyVaultSmokeTests>()
+                .Build();
+
+            var azureSettings = configuration.GetSection("Azure").Get<AzureSettings>();
+
+            azureSettings.ShouldNotBeNull("The Azure section must exist in the Hippo.Web user-secrets file.");
+            azureSettings.ClientId.ShouldNotBeNullOrWhiteSpace("Azure:ClientId must be set.");
+            azureSettings.ClientSecret.ShouldNotBeNullOrWhiteSpace("Azure:ClientSecret must be set.");
+            azureSettings.KeyVaultUrl.ShouldNotBeNullOrWhiteSpace("Azure:KeyVaultUrl must be set.");
+
+            return azureSettings;
+        }
+    }
+}

--- a/Test/KeyVaultSmokeTests.cs
+++ b/Test/KeyVaultSmokeTests.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Net;
 using System.Threading.Tasks;
 using Hippo.Core.Models.Settings;
 using Hippo.Core.Services;
+using Microsoft.Azure.KeyVault.Models;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 using Shouldly;
@@ -39,12 +41,10 @@ namespace Test
             var secretsService = new SecretsService(Options.Create(azureSettings));
             var secretName = $"hippo-smoke-test-{Guid.NewGuid():N}";
             var secretValue = $"smoke-test-value-{Guid.NewGuid():N}";
-            var secretWasCreated = false;
 
             try
             {
                 await secretsService.SetSecret(secretName, secretValue);
-                secretWasCreated = true;
 
                 var retrievedSecret = await secretsService.GetSecret(secretName);
 
@@ -52,9 +52,12 @@ namespace Test
             }
             finally
             {
-                if (secretWasCreated)
+                try
                 {
                     await secretsService.DeleteSecret(secretName);
+                }
+                catch (KeyVaultErrorException ex) when (ex.Response?.StatusCode == HttpStatusCode.NotFound)
+                {
                 }
             }
         }

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -3,9 +3,11 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <UserSecretsId>c14737e0-e801-4dfa-bc8d-ce9130c807c6</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AspNetCore.TestHelpers" Version="1.1.14" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with instructions for running optional Key Vault integration smoke tests via environment variable configuration

* **Tests**
  * Added conditional integration smoke tests that validate Key Vault secret operations (write, read, and delete functionality)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->