### PR TITLE
Fix user/account issues

### DIFF
--- a/Hippo.Core/Services/AccountOwnershipService.cs
+++ b/Hippo.Core/Services/AccountOwnershipService.cs
@@ -1,6 +1,7 @@
 using Hippo.Core.Data;
 using Hippo.Core.Domain;
 using Microsoft.EntityFrameworkCore;
+using Serilog;
 
 namespace Hippo.Core.Services;
 
@@ -10,6 +11,15 @@ public static class AccountOwnershipService
     {
         if (string.IsNullOrWhiteSpace(user.Kerberos))
         {
+            return 0;
+        }
+
+        if (await HasMultipleUsersWithKerberos(dbContext, user.Kerberos))
+        {
+            Log.Warning(
+                "Multiple users found with Kerberos {Kerberos}. Skipping account ownership linking for user {UserId}.",
+                user.Kerberos,
+                user.Id);
             return 0;
         }
 
@@ -32,16 +42,36 @@ public static class AccountOwnershipService
             return false;
         }
 
-        var user = await dbContext.Users
+        var users = await dbContext.Users
             .Where(u => u.Kerberos == account.Kerberos)
-            .FirstOrDefaultAsync();
+            .Take(2)
+            .ToListAsync();
 
-        if (user == null)
+        if (users.Count == 0)
         {
             return false;
         }
 
-        account.Owner = user;
+        if (users.Count > 1)
+        {
+            Log.Warning(
+                "Multiple users found with Kerberos {Kerberos}. Skipping owner assignment for account {AccountId}.",
+                account.Kerberos,
+                account.Id);
+            return false;
+        }
+
+        account.Owner = users.Single();
         return true;
+    }
+
+    private static async Task<bool> HasMultipleUsersWithKerberos(AppDbContext dbContext, string kerberos)
+    {
+        var userCount = await dbContext.Users
+            .Where(u => u.Kerberos == kerberos)
+            .Take(2)
+            .CountAsync();
+
+        return userCount > 1;
     }
 }

--- a/Hippo.Core/Services/AccountOwnershipService.cs
+++ b/Hippo.Core/Services/AccountOwnershipService.cs
@@ -14,7 +14,7 @@ public static class AccountOwnershipService
             return 0;
         }
 
-        if (await HasMultipleUsersWithKerberos(dbContext, user.Kerberos))
+        if (await HasConflictingUserWithKerberos(dbContext, user))
         {
             Log.Warning(
                 "Multiple users found with Kerberos {Kerberos}. Skipping account ownership linking for user {UserId}.",
@@ -65,13 +65,16 @@ public static class AccountOwnershipService
         return true;
     }
 
-    private static async Task<bool> HasMultipleUsersWithKerberos(AppDbContext dbContext, string kerberos)
+    private static async Task<bool> HasConflictingUserWithKerberos(AppDbContext dbContext, User user)
     {
-        var userCount = await dbContext.Users
-            .Where(u => u.Kerberos == kerberos)
+        var matchingUserIds = await dbContext.Users
+            .Where(u => u.Kerberos == user.Kerberos)
+            .Select(u => u.Id)
             .Take(2)
-            .CountAsync();
+            .ToListAsync();
 
-        return userCount > 1;
+        return user.Id == 0
+            ? matchingUserIds.Count > 0
+            : matchingUserIds.Any(id => id != user.Id);
     }
 }

--- a/Hippo.Core/Services/AccountOwnershipService.cs
+++ b/Hippo.Core/Services/AccountOwnershipService.cs
@@ -1,0 +1,47 @@
+using Hippo.Core.Data;
+using Hippo.Core.Domain;
+using Microsoft.EntityFrameworkCore;
+
+namespace Hippo.Core.Services;
+
+public static class AccountOwnershipService
+{
+    public static async Task<int> LinkAccountsToUser(AppDbContext dbContext, User user)
+    {
+        if (string.IsNullOrWhiteSpace(user.Kerberos))
+        {
+            return 0;
+        }
+
+        var accounts = await dbContext.Accounts
+            .Where(a => a.OwnerId == null && a.Kerberos == user.Kerberos)
+            .ToListAsync();
+
+        foreach (var account in accounts)
+        {
+            account.Owner = user;
+        }
+
+        return accounts.Count;
+    }
+
+    public static async Task<bool> LinkAccountToMatchingUser(AppDbContext dbContext, Account account)
+    {
+        if (account.OwnerId != null || string.IsNullOrWhiteSpace(account.Kerberos))
+        {
+            return false;
+        }
+
+        var user = await dbContext.Users
+            .Where(u => u.Kerberos == account.Kerberos)
+            .FirstOrDefaultAsync();
+
+        if (user == null)
+        {
+            return false;
+        }
+
+        account.Owner = user;
+        return true;
+    }
+}

--- a/Hippo.Core/Services/AccountOwnershipService.cs
+++ b/Hippo.Core/Services/AccountOwnershipService.cs
@@ -16,10 +16,19 @@ public static class AccountOwnershipService
 
         if (await HasConflictingUserWithKerberos(dbContext, user))
         {
-            Log.Warning(
-                "Multiple users found with Kerberos {Kerberos}. Skipping account ownership linking for user {UserId}.",
-                user.Kerberos,
-                user.Id);
+            if (user.Id == 0)
+            {
+                Log.Warning(
+                    "User Kerberos {Kerberos} would duplicate an existing user. Skipping account ownership linking for new user.",
+                    user.Kerberos);
+            }
+            else
+            {
+                Log.Warning(
+                    "Multiple users found with Kerberos {Kerberos}. Skipping account ownership linking for user {UserId}.",
+                    user.Kerberos,
+                    user.Id);
+            }
             return 0;
         }
 

--- a/Hippo.Core/Services/AccountSyncService.cs
+++ b/Hippo.Core/Services/AccountSyncService.cs
@@ -69,9 +69,12 @@ namespace Hippo.Core.Services
                     .Where(a => a.OwnerId != null && !string.IsNullOrEmpty(a.Kerberos))
                     .Select(a => new { a.ClusterId, a.Kerberos, a.OwnerId })
                     .ToListAsync();
-                var mapAccountKeysToOwnerIds = existingOwnerIdsForAccounts
-                    .GroupBy(a => (a.ClusterId, a.Kerberos))
-                    .ToDictionary(g => g.Key, g => g.First().OwnerId);
+                var mapAccountKeysToOwnerIds = AccountSyncPlanner.GetExistingOwnerIdsByAccountKey(
+                    existingOwnerIdsForAccounts.Select(a => new ExistingAccountOwnerSyncState(
+                        a.ClusterId,
+                        a.Kerberos,
+                        a.OwnerId)),
+                    mapKerbsToUserIds);
 
                 // Setup desired state of groups and accounts
                 // This will effectively undelete any that are soft-deleted
@@ -336,6 +339,7 @@ namespace Hippo.Core.Services
 
     internal record GroupMemberAccountSyncState(int GroupId, int AccountId, int ClusterId);
     internal record UserKerberosSyncState(int UserId, string Kerberos);
+    internal record ExistingAccountOwnerSyncState(int ClusterId, string Kerberos, int? OwnerId);
 
     internal static class AccountSyncPlanner
     {
@@ -407,6 +411,47 @@ namespace Hippo.Core.Services
                     return false;
                 })
                 .ToDictionary(g => g.Key, g => g.Single().UserId);
+        }
+
+        public static Dictionary<(int ClusterId, string Kerberos), int?> GetExistingOwnerIdsByAccountKey(
+            IEnumerable<ExistingAccountOwnerSyncState> existingAccounts,
+            IReadOnlyDictionary<string, int> uniqueUserIdsByKerberos)
+        {
+            return existingAccounts
+                .GroupBy(a => (a.ClusterId, a.Kerberos))
+                .Select(g =>
+                {
+                    var ownerIds = g
+                        .Select(a => a.OwnerId)
+                        .Where(ownerId => ownerId != null)
+                        .Distinct()
+                        .ToArray();
+
+                    if (ownerIds.Length == 1)
+                    {
+                        return new { g.Key, OwnerId = ownerIds.Single(), HasOwner = true };
+                    }
+
+                    if (ownerIds.Length == 0)
+                    {
+                        return new { g.Key, OwnerId = (int?)null, HasOwner = false };
+                    }
+
+                    Log.Warning(
+                        "Multiple account owners found for ClusterId {ClusterId} and Kerberos {Kerberos} during account sync. Falling back to unique Kerberos user owner assignment. OwnerIds: {OwnerIds}",
+                        g.Key.ClusterId,
+                        g.Key.Kerberos,
+                        ownerIds);
+
+                    if (uniqueUserIdsByKerberos.TryGetValue(g.Key.Kerberos, out var userId))
+                    {
+                        return new { g.Key, OwnerId = (int?)userId, HasOwner = true };
+                    }
+
+                    return new { g.Key, OwnerId = (int?)null, HasOwner = false };
+                })
+                .Where(x => x.HasOwner)
+                .ToDictionary(x => x.Key, x => x.OwnerId);
         }
 
         public static int? GetDesiredOwnerId(

--- a/Hippo.Core/Services/AccountSyncService.cs
+++ b/Hippo.Core/Services/AccountSyncService.cs
@@ -66,12 +66,12 @@ namespace Hippo.Core.Services
                     usersMatchingSyncedKerberos.Select(u => new UserKerberosSyncState(u.Id, u.Kerberos)));
                 var ambiguousKerberos = AccountSyncPlanner.GetAmbiguousKerberos(
                     usersMatchingSyncedKerberos.Select(u => new UserKerberosSyncState(u.Id, u.Kerberos)));
-                var existingOwnerIdsForAmbiguousAccounts = await _dbContext.Accounts
+                var existingOwnerIdsForAccounts = await _dbContext.Accounts
                     .IgnoreQueryFilters()
-                    .Where(a => a.Kerberos != null && ambiguousKerberos.Contains(a.Kerberos))
+                    .Where(a => a.OwnerId != null && !string.IsNullOrEmpty(a.Kerberos))
                     .Select(a => new { a.ClusterId, a.Kerberos, a.OwnerId })
                     .ToListAsync();
-                var mapAmbiguousAccountKeysToOwnerIds = existingOwnerIdsForAmbiguousAccounts
+                var mapAccountKeysToOwnerIds = existingOwnerIdsForAccounts
                     .GroupBy(a => (a.ClusterId, a.Kerberos))
                     .ToDictionary(g => g.Key, g => g.First().OwnerId);
 
@@ -88,7 +88,7 @@ namespace Hippo.Core.Services
                             u.Kerberos,
                             mapKerbsToUserIds,
                             ambiguousKerberos,
-                            mapAmbiguousAccountKeysToOwnerIds),
+                            mapAccountKeysToOwnerIds),
                         ClusterId = x.Key,
                         CreatedOn = now,
                         UpdatedOn = now,
@@ -433,7 +433,7 @@ namespace Hippo.Core.Services
                 return userId;
             }
 
-            return ambiguousKerberos.Contains(kerberos)
+            return (ambiguousKerberos.Contains(kerberos) || !uniqueUserIdsByKerberos.ContainsKey(kerberos))
                 && existingOwnerIdsByAccountKey.TryGetValue((clusterId, kerberos), out var existingOwnerId)
                     ? existingOwnerId
                     : null;

--- a/Hippo.Core/Services/AccountSyncService.cs
+++ b/Hippo.Core/Services/AccountSyncService.cs
@@ -64,8 +64,6 @@ namespace Hippo.Core.Services
                     .ToListAsync();
                 var mapKerbsToUserIds = AccountSyncPlanner.GetUniqueUserIdsByKerberos(
                     usersMatchingSyncedKerberos.Select(u => new UserKerberosSyncState(u.Id, u.Kerberos)));
-                var ambiguousKerberos = AccountSyncPlanner.GetAmbiguousKerberos(
-                    usersMatchingSyncedKerberos.Select(u => new UserKerberosSyncState(u.Id, u.Kerberos)));
                 var existingOwnerIdsForAccounts = await _dbContext.Accounts
                     .IgnoreQueryFilters()
                     .Where(a => a.OwnerId != null && !string.IsNullOrEmpty(a.Kerberos))
@@ -87,7 +85,6 @@ namespace Hippo.Core.Services
                             x.Key,
                             u.Kerberos,
                             mapKerbsToUserIds,
-                            ambiguousKerberos,
                             mapAccountKeysToOwnerIds),
                         ClusterId = x.Key,
                         CreatedOn = now,
@@ -412,31 +409,23 @@ namespace Hippo.Core.Services
                 .ToDictionary(g => g.Key, g => g.Single().UserId);
         }
 
-        public static HashSet<string> GetAmbiguousKerberos(IEnumerable<UserKerberosSyncState> users)
-        {
-            return users
-                .GroupBy(u => u.Kerberos)
-                .Where(g => g.Count() > 1)
-                .Select(g => g.Key)
-                .ToHashSet();
-        }
-
         public static int? GetDesiredOwnerId(
             int clusterId,
             string kerberos,
             IReadOnlyDictionary<string, int> uniqueUserIdsByKerberos,
-            IReadOnlySet<string> ambiguousKerberos,
             IReadOnlyDictionary<(int ClusterId, string Kerberos), int?> existingOwnerIdsByAccountKey)
         {
+            if (existingOwnerIdsByAccountKey.TryGetValue((clusterId, kerberos), out var existingOwnerId))
+            {
+                return existingOwnerId;
+            }
+
             if (uniqueUserIdsByKerberos.TryGetValue(kerberos, out var userId))
             {
                 return userId;
             }
 
-            return (ambiguousKerberos.Contains(kerberos) || !uniqueUserIdsByKerberos.ContainsKey(kerberos))
-                && existingOwnerIdsByAccountKey.TryGetValue((clusterId, kerberos), out var existingOwnerId)
-                    ? existingOwnerId
-                    : null;
+            return null;
         }
     }
 }

--- a/Hippo.Core/Services/AccountSyncService.cs
+++ b/Hippo.Core/Services/AccountSyncService.cs
@@ -58,10 +58,12 @@ namespace Hippo.Core.Services
                 await _dbContext.BulkInsertAsync(mapClusterIdsToPuppetData.SelectMany(x => x.Value.PuppetData.Users.Select(u => new TempKerberos { ClusterId = x.Key, Kerberos = u.Kerberos })));
                 await _dbContext.BulkInsertAsync(mapClusterIdsToPuppetData.SelectMany(x => x.Value.PuppetData.GroupsWithSponsors.Select(g => new TempGroup { ClusterId = x.Key, Group = g.Name })));
 
-                var mapKerbsToUserIds = await _dbContext.Users
+                var usersMatchingSyncedKerberos = await _dbContext.Users
                     .Where(u => _dbContext.TempKerberos.Any(tg => tg.Kerberos == u.Kerberos))
                     .Select(u => new { u.Id, u.Kerberos })
-                    .ToDictionaryAsync(k => k.Kerberos, v => v.Id);
+                    .ToListAsync();
+                var mapKerbsToUserIds = AccountSyncPlanner.GetUniqueUserIdsByKerberos(
+                    usersMatchingSyncedKerberos.Select(u => new UserKerberosSyncState(u.Id, u.Kerberos)));
 
                 // Setup desired state of groups and accounts
                 // This will effectively undelete any that are soft-deleted
@@ -321,6 +323,7 @@ namespace Hippo.Core.Services
     }
 
     internal record GroupMemberAccountSyncState(int GroupId, int AccountId, int ClusterId);
+    internal record UserKerberosSyncState(int UserId, string Kerberos);
 
     internal static class AccountSyncPlanner
     {
@@ -372,6 +375,26 @@ namespace Hippo.Core.Services
                 .Where(gma => !deleteGroupAccountKeys.Contains((gma.GroupId, gma.AccountId)))
                 .Concat(deleteGroupAccounts)
                 .ToList();
+        }
+
+        public static Dictionary<string, int> GetUniqueUserIdsByKerberos(IEnumerable<UserKerberosSyncState> users)
+        {
+            return users
+                .GroupBy(u => u.Kerberos)
+                .Where(g =>
+                {
+                    if (g.Count() == 1)
+                    {
+                        return true;
+                    }
+
+                    Log.Warning(
+                        "Multiple users found with Kerberos {Kerberos} during account sync. Skipping owner assignment for matching accounts. UserIds: {UserIds}",
+                        g.Key,
+                        g.Select(u => u.UserId).ToArray());
+                    return false;
+                })
+                .ToDictionary(g => g.Key, g => g.Single().UserId);
         }
     }
 }

--- a/Hippo.Core/Services/AccountSyncService.cs
+++ b/Hippo.Core/Services/AccountSyncService.cs
@@ -136,10 +136,11 @@ namespace Hippo.Core.Services
                         nameof(Account.CreatedOn),
                         nameof(Account.AcceptableUsePolicyAgreedOn) },
                     // PropertiesToIncludeOnCompare is more explicit than PropertiesToExcludeOnCompare on what differences
-                    // can be used to trigger an update. We're only interested when Name, Email, Data or IsActive changes...
+                    // can be used to trigger an update. We're only interested when synced account fields or ownership changes...
                     PropertiesToIncludeOnCompare = new List<string> {
                         nameof(Account.Name),
                         nameof(Account.Email),
+                        nameof(Account.OwnerId),
                         nameof(Account.Data),
                         nameof(Account.DeactivatedOn) },
                     UpdateByProperties = new List<string> { nameof(Account.ClusterId), nameof(Account.Kerberos) },

--- a/Hippo.Core/Services/AccountSyncService.cs
+++ b/Hippo.Core/Services/AccountSyncService.cs
@@ -64,6 +64,16 @@ namespace Hippo.Core.Services
                     .ToListAsync();
                 var mapKerbsToUserIds = AccountSyncPlanner.GetUniqueUserIdsByKerberos(
                     usersMatchingSyncedKerberos.Select(u => new UserKerberosSyncState(u.Id, u.Kerberos)));
+                var ambiguousKerberos = AccountSyncPlanner.GetAmbiguousKerberos(
+                    usersMatchingSyncedKerberos.Select(u => new UserKerberosSyncState(u.Id, u.Kerberos)));
+                var existingOwnerIdsForAmbiguousAccounts = await _dbContext.Accounts
+                    .IgnoreQueryFilters()
+                    .Where(a => a.Kerberos != null && ambiguousKerberos.Contains(a.Kerberos))
+                    .Select(a => new { a.ClusterId, a.Kerberos, a.OwnerId })
+                    .ToListAsync();
+                var mapAmbiguousAccountKeysToOwnerIds = existingOwnerIdsForAmbiguousAccounts
+                    .GroupBy(a => (a.ClusterId, a.Kerberos))
+                    .ToDictionary(g => g.Key, g => g.First().OwnerId);
 
                 // Setup desired state of groups and accounts
                 // This will effectively undelete any that are soft-deleted
@@ -73,7 +83,12 @@ namespace Hippo.Core.Services
                         Name = u.Name,
                         Email = u.Email,
                         Kerberos = u.Kerberos,
-                        OwnerId = mapKerbsToUserIds.ContainsKey(u.Kerberos) ? mapKerbsToUserIds[u.Kerberos] : null,
+                        OwnerId = AccountSyncPlanner.GetDesiredOwnerId(
+                            x.Key,
+                            u.Kerberos,
+                            mapKerbsToUserIds,
+                            ambiguousKerberos,
+                            mapAmbiguousAccountKeysToOwnerIds),
                         ClusterId = x.Key,
                         CreatedOn = now,
                         UpdatedOn = now,
@@ -395,6 +410,33 @@ namespace Hippo.Core.Services
                     return false;
                 })
                 .ToDictionary(g => g.Key, g => g.Single().UserId);
+        }
+
+        public static HashSet<string> GetAmbiguousKerberos(IEnumerable<UserKerberosSyncState> users)
+        {
+            return users
+                .GroupBy(u => u.Kerberos)
+                .Where(g => g.Count() > 1)
+                .Select(g => g.Key)
+                .ToHashSet();
+        }
+
+        public static int? GetDesiredOwnerId(
+            int clusterId,
+            string kerberos,
+            IReadOnlyDictionary<string, int> uniqueUserIdsByKerberos,
+            IReadOnlySet<string> ambiguousKerberos,
+            IReadOnlyDictionary<(int ClusterId, string Kerberos), int?> existingOwnerIdsByAccountKey)
+        {
+            if (uniqueUserIdsByKerberos.TryGetValue(kerberos, out var userId))
+            {
+                return userId;
+            }
+
+            return ambiguousKerberos.Contains(kerberos)
+                && existingOwnerIdsByAccountKey.TryGetValue((clusterId, kerberos), out var existingOwnerId)
+                    ? existingOwnerId
+                    : null;
         }
     }
 }

--- a/Hippo.Core/Services/AccountUpdateService.cs
+++ b/Hippo.Core/Services/AccountUpdateService.cs
@@ -99,6 +99,12 @@ namespace Hippo.Core.Services
             var data = queuedEvent.Data;
             var accountModel = data.Accounts.FirstOrDefault();
             var groupModel = data.Groups.FirstOrDefault();
+
+            if (accountModel == null || groupModel == null)
+            {
+                return Result.Error("Invalid data: action {Action} requires one account and one group", QueuedEvent.Actions.AddAccountToGroup);
+            }
+
             var account = await _dbContext.Accounts
                 .Include(a => a.MemberOfGroups)
                 .Where(a => a.Cluster.Name == data.Cluster && a.Kerberos == accountModel.Kerberos)
@@ -107,15 +113,12 @@ namespace Hippo.Core.Services
                 .Where(g => g.Cluster.Name == data.Cluster && g.Name == groupModel.Name)
                 .FirstOrDefaultAsync();
 
-            if (accountModel == null || groupModel == null)
-            {
-                return Result.Error("Invalid data: action {Action} requires one account and one group", QueuedEvent.Actions.AddAccountToGroup);
-            }
-
             if (account == null)
             {
                 return Result.Error("Account not found: {Kerberos} on cluster {Cluster}", accountModel.Kerberos, data.Cluster);
             }
+
+            await AccountOwnershipService.LinkAccountToMatchingUser(_dbContext, account);
 
             if (group == null)
             {
@@ -136,24 +139,29 @@ namespace Hippo.Core.Services
             var data = queuedEvent.Data;
             var accountModel = data.Accounts.FirstOrDefault();
             var groupModel = data.Groups.FirstOrDefault();
-            var account = await _dbContext.Accounts
-                .Where(a => a.Cluster.Name == data.Cluster && a.Kerberos == accountModel.Kerberos)
-                .FirstOrDefaultAsync();
-            var user = await _dbContext.Users
-                .Where(u => u.Kerberos == accountModel.Kerberos)
-                .FirstOrDefaultAsync();
-            var group = await _dbContext.Groups
-                .Where(g => g.Cluster.Name == data.Cluster && g.Name == groupModel.Name)
-                .FirstOrDefaultAsync();
 
             if (accountModel == null || groupModel == null)
             {
                 return Result.Error("Invalid data: action {Action} requires one account and one group", QueuedEvent.Actions.CreateAccount);
             }
 
+            var account = await _dbContext.Accounts
+                .Include(a => a.MemberOfGroups)
+                .Where(a => a.Cluster.Name == data.Cluster && a.Kerberos == accountModel.Kerberos)
+                .FirstOrDefaultAsync();
+            var user = await GetQueuedAccountUser(queuedEvent, accountModel);
+            var group = await _dbContext.Groups
+                .Where(g => g.Cluster.Name == data.Cluster && g.Name == groupModel.Name)
+                .FirstOrDefaultAsync();
+
             if (group == null)
             {
                 return Result.Error("Group not found: {Name} on cluster {Cluster}", groupModel.Name, data.Cluster);
+            }
+
+            if (queuedEvent.Request == null)
+            {
+                return Result.Error("Invalid data: action {Action} requires an associated request", QueuedEvent.Actions.CreateAccount);
             }
 
             if (user == null)
@@ -163,7 +171,21 @@ namespace Hippo.Core.Services
 
             if (account != null)
             {
-                return Result.Error("Account already exists: {Kerberos} on cluster {Cluster}", accountModel.Kerberos, data.Cluster);
+                if (account.OwnerId != null && account.OwnerId != user.Id)
+                {
+                    return Result.Error("Account already exists for a different user: {Kerberos} on cluster {Cluster}", accountModel.Kerberos, data.Cluster);
+                }
+
+                account.Owner = user;
+                if (!account.MemberOfGroups.Any(g => g.Id == group.Id))
+                {
+                    account.MemberOfGroups.Add(group);
+                }
+
+                var existingAccountRequestData = queuedEvent.Request.GetAccountRequestData();
+                account.AcceptableUsePolicyAgreedOn ??= existingAccountRequestData.AcceptableUsePolicyAgreedOn;
+                account.SupervisingPIId ??= existingAccountRequestData.SupervisingPIUserId == 0 ? null : existingAccountRequestData.SupervisingPIUserId;
+                return Result.Ok();
             }
 
             var accountRequestData = queuedEvent.Request.GetAccountRequestData();
@@ -216,6 +238,8 @@ namespace Hippo.Core.Services
                 return Result.Error("Account does not exist: {Kerberos} on cluster {Cluster}", accountModel.Kerberos, data.Cluster);
             }
 
+            await AccountOwnershipService.LinkAccountToMatchingUser(_dbContext, account);
+
             if (group == null)
             {
                 var newGroup = new Group
@@ -244,19 +268,22 @@ namespace Hippo.Core.Services
         {
             var data = queuedEvent.Data;
             var accountModel = data.Accounts.FirstOrDefault();
-            var account = await _dbContext.Accounts
-                .Where(a => a.Cluster.Name == data.Cluster && a.Kerberos == accountModel.Kerberos)
-                .FirstOrDefaultAsync();
 
             if (accountModel == null || string.IsNullOrWhiteSpace(accountModel.Key))
             {
                 return Result.Error("Invalid data: action {Action} requires one account and a key", QueuedEvent.Actions.UpdateSshKey);
             }
 
+            var account = await _dbContext.Accounts
+                .Where(a => a.Cluster.Name == data.Cluster && a.Kerberos == accountModel.Kerberos)
+                .FirstOrDefaultAsync();
+
             if (account == null)
             {
                 return Result.Error("Account not found: {Kerberos} on cluster {Cluster}", accountModel.Kerberos, data.Cluster);
             }
+
+            await AccountOwnershipService.LinkAccountToMatchingUser(_dbContext, account);
 
             account.SshKey = accountModel.Key;
             // _dbContext.SaveAsync() is handled elsewhere for this change
@@ -268,20 +295,23 @@ namespace Hippo.Core.Services
             var data = queuedEvent.Data;
             var accountModel = data.Accounts.FirstOrDefault();
             var groupModel = data.Groups.FirstOrDefault();
-            var account = await _dbContext.Accounts
-                .Include(a => a.MemberOfGroups.Where(g => g.Name == groupModel.Name))
-                .Where(a => a.Cluster.Name == data.Cluster && a.Kerberos == accountModel.Kerberos)
-                .FirstOrDefaultAsync();
 
             if (accountModel == null || groupModel == null)
             {
                 return Result.Error("Invalid data: action {Action} requires one account and one group", QueuedEvent.Actions.RemoveAccountFromGroup);
             }
 
+            var account = await _dbContext.Accounts
+                .Include(a => a.MemberOfGroups.Where(g => g.Name == groupModel.Name))
+                .Where(a => a.Cluster.Name == data.Cluster && a.Kerberos == accountModel.Kerberos)
+                .FirstOrDefaultAsync();
+
             if (account == null)
             {
                 return Result.Error("Account not found: {Kerberos} on cluster {Cluster}", accountModel.Kerberos, data.Cluster);
             }
+
+            await AccountOwnershipService.LinkAccountToMatchingUser(_dbContext, account);
 
             if (!account.MemberOfGroups.Any())
             {
@@ -293,6 +323,40 @@ namespace Hippo.Core.Services
 
             // _dbContext.SaveAsync() is handled elsewhere for this change
             return Result.Ok();
+        }
+
+        private async Task<User> GetQueuedAccountUser(QueuedEvent queuedEvent, QueuedEventAccountModel accountModel)
+        {
+            if (!string.IsNullOrWhiteSpace(accountModel.Iam))
+            {
+                var user = await _dbContext.Users
+                    .Where(u => u.Iam == accountModel.Iam)
+                    .FirstOrDefaultAsync();
+                if (user != null)
+                {
+                    return user;
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(accountModel.Kerberos))
+            {
+                var user = await _dbContext.Users
+                    .Where(u => u.Kerberos == accountModel.Kerberos)
+                    .FirstOrDefaultAsync();
+                if (user != null)
+                {
+                    return user;
+                }
+            }
+
+            if (queuedEvent.Request?.RequesterId > 0)
+            {
+                return await _dbContext.Users
+                    .Where(u => u.Id == queuedEvent.Request.RequesterId)
+                    .FirstOrDefaultAsync();
+            }
+
+            return null;
         }
     }
 

--- a/Hippo.Core/Services/AccountUpdateService.cs
+++ b/Hippo.Core/Services/AccountUpdateService.cs
@@ -140,7 +140,7 @@ namespace Hippo.Core.Services
             var accountModel = data.Accounts.FirstOrDefault();
             var groupModel = data.Groups.FirstOrDefault();
 
-            if (accountModel == null || groupModel == null)
+            if (accountModel == null || groupModel == null || string.IsNullOrWhiteSpace(accountModel.Kerberos))
             {
                 return Result.Error("Invalid data: action {Action} requires one account and one group", QueuedEvent.Actions.CreateAccount);
             }
@@ -172,6 +172,14 @@ namespace Hippo.Core.Services
             if (user == null)
             {
                 return Result.Error("User not found: {Kerberos}", accountModel.Kerberos);
+            }
+
+            if (!string.Equals(user.Kerberos, accountModel.Kerberos, StringComparison.OrdinalIgnoreCase))
+            {
+                return Result.Error(
+                    "Queued account Kerberos {Kerberos} does not match resolved user Kerberos {UserKerberos}",
+                    accountModel.Kerberos,
+                    user.Kerberos);
             }
 
             if (account != null)

--- a/Hippo.Core/Services/AccountUpdateService.cs
+++ b/Hippo.Core/Services/AccountUpdateService.cs
@@ -149,7 +149,12 @@ namespace Hippo.Core.Services
                 .Include(a => a.MemberOfGroups)
                 .Where(a => a.Cluster.Name == data.Cluster && a.Kerberos == accountModel.Kerberos)
                 .FirstOrDefaultAsync();
-            var user = await GetQueuedAccountUser(queuedEvent, accountModel);
+            var userResult = await GetQueuedAccountUser(queuedEvent, accountModel);
+            if (userResult.IsError)
+            {
+                return userResult;
+            }
+            var user = userResult.Value;
             var group = await _dbContext.Groups
                 .Where(g => g.Cluster.Name == data.Cluster && g.Name == groupModel.Name)
                 .FirstOrDefaultAsync();
@@ -325,7 +330,7 @@ namespace Hippo.Core.Services
             return Result.Ok();
         }
 
-        private async Task<User> GetQueuedAccountUser(QueuedEvent queuedEvent, QueuedEventAccountModel accountModel)
+        private async Task<Result<User>> GetQueuedAccountUser(QueuedEvent queuedEvent, QueuedEventAccountModel accountModel)
         {
             if (!string.IsNullOrWhiteSpace(accountModel.Iam))
             {
@@ -334,29 +339,34 @@ namespace Hippo.Core.Services
                     .FirstOrDefaultAsync();
                 if (user != null)
                 {
-                    return user;
+                    return Result.Value(user);
                 }
             }
 
             if (!string.IsNullOrWhiteSpace(accountModel.Kerberos))
             {
-                var user = await _dbContext.Users
+                var users = await _dbContext.Users
                     .Where(u => u.Kerberos == accountModel.Kerberos)
-                    .FirstOrDefaultAsync();
-                if (user != null)
+                    .Take(2)
+                    .ToListAsync();
+                if (users.Count > 1)
                 {
-                    return user;
+                    return Result.Error("Multiple users found for Kerberos {Kerberos}; cannot determine account owner", accountModel.Kerberos);
+                }
+                if (users.Count == 1)
+                {
+                    return Result.Value(users.Single());
                 }
             }
 
             if (queuedEvent.Request?.RequesterId > 0)
             {
-                return await _dbContext.Users
+                return Result.Value(await _dbContext.Users
                     .Where(u => u.Id == queuedEvent.Request.RequesterId)
-                    .FirstOrDefaultAsync();
+                    .FirstOrDefaultAsync());
             }
 
-            return null;
+            return Result.Value<User>(null);
         }
     }
 

--- a/Hippo.Core/Services/AccountUpdateService.cs
+++ b/Hippo.Core/Services/AccountUpdateService.cs
@@ -174,7 +174,8 @@ namespace Hippo.Core.Services
                 return Result.Error("User not found: {Kerberos}", accountModel.Kerberos);
             }
 
-            if (!string.Equals(user.Kerberos, accountModel.Kerberos, StringComparison.OrdinalIgnoreCase))
+            if (!string.IsNullOrWhiteSpace(user.Kerberos)
+                && !string.Equals(user.Kerberos, accountModel.Kerberos, StringComparison.OrdinalIgnoreCase))
             {
                 return Result.Error(
                     "Queued account Kerberos {Kerberos} does not match resolved user Kerberos {UserKerberos}",
@@ -190,6 +191,7 @@ namespace Hippo.Core.Services
                 }
 
                 account.Owner = user;
+                account.SshKey = accountModel.Key;
                 if (!account.MemberOfGroups.Any(g => g.Id == group.Id))
                 {
                     account.MemberOfGroups.Add(group);

--- a/Hippo.Core/Services/IdentityService.cs
+++ b/Hippo.Core/Services/IdentityService.cs
@@ -3,6 +3,7 @@ using Hippo.Core.Domain;
 using Hippo.Core.Models.Settings;
 using Ietws;
 using Microsoft.Extensions.Options;
+using Serilog;
 
 namespace Hippo.Core.Services
 {
@@ -60,9 +61,14 @@ namespace Hippo.Core.Services
             {
                 var iamIds = ucdKerbResult.ResponseData.Results.Select(a => a.IamId).Distinct().ToArray();
                 var userIDs = ucdKerbResult.ResponseData.Results.Select(a => a.UserId).Distinct().ToArray();
-                if (iamIds.Length != 1 && userIDs.Length != 1)
+                if (iamIds.Length != 1 || userIDs.Length != 1)
                 {
-                    throw new Exception($"IAM issue with non unique values for kerbs: {string.Join(',', userIDs)} IAM: {string.Join(',', iamIds)}");
+                    Log.Warning(
+                        "IAM returned multiple records for Kerberos {Kerberos}. UserIds: {UserIds}; IamIds: {IamIds}",
+                        kerb,
+                        userIDs,
+                        iamIds);
+                    return null;
                 }
             }
 

--- a/Hippo.Core/Services/UserService.cs
+++ b/Hippo.Core/Services/UserService.cs
@@ -177,10 +177,15 @@ namespace Hippo.Core.Services
 
             if (dbUser != null)
             {
+                var accountLinksUpdated = await AccountOwnershipService.LinkAccountsToUser(_dbContext, dbUser);
                 if (dbUser.MothraId == null)
                 {
                     var foundUser = await _identityService.GetByKerberos(dbUser.Kerberos);
                     dbUser.MothraId = foundUser.MothraId;
+                    await _dbContext.SaveChangesAsync();
+                }
+                else if (accountLinksUpdated > 0)
+                {
                     await _dbContext.SaveChangesAsync();
                 }
 
@@ -204,14 +209,7 @@ namespace Hippo.Core.Services
                 await _dbContext.Users.AddAsync(newUser);
 
                 // check if any existing accounts need to be associated with this user
-                var existingAccounts = await _dbContext.Accounts.Where(a => a.Kerberos == newUser.Kerberos).ToArrayAsync();
-                if (existingAccounts.Length > 0)
-                {
-                    foreach (var account in existingAccounts)
-                    {
-                        account.Owner = newUser;
-                    }
-                }
+                await AccountOwnershipService.LinkAccountsToUser(_dbContext, newUser);
 
                 await _dbContext.SaveChangesAsync();
 
@@ -227,6 +225,11 @@ namespace Hippo.Core.Services
 
             if (user != null)
             {
+                var accountLinksUpdated = await AccountOwnershipService.LinkAccountsToUser(_dbContext, user);
+                if (accountLinksUpdated > 0)
+                {
+                    await _dbContext.SaveChangesAsync();
+                }
                 return user;
             }
 
@@ -235,6 +238,7 @@ namespace Hippo.Core.Services
             if (user != null)
             {
                 await _dbContext.Users.AddAsync(user);
+                await AccountOwnershipService.LinkAccountsToUser(_dbContext, user);
                 await _dbContext.SaveChangesAsync();
             }
 

--- a/Hippo.Core/Services/UserService.cs
+++ b/Hippo.Core/Services/UserService.cs
@@ -181,8 +181,22 @@ namespace Hippo.Core.Services
                 if (dbUser.MothraId == null)
                 {
                     var foundUser = await _identityService.GetByKerberos(dbUser.Kerberos);
-                    dbUser.MothraId = foundUser.MothraId;
-                    await _dbContext.SaveChangesAsync();
+                    if (foundUser == null)
+                    {
+                        Log.Warning(
+                            "Unable to update MothraId for user {UserId} because Kerberos {Kerberos} could not be resolved uniquely in IAM.",
+                            dbUser.Id,
+                            dbUser.Kerberos);
+                        if (accountLinksUpdated > 0)
+                        {
+                            await _dbContext.SaveChangesAsync();
+                        }
+                    }
+                    else
+                    {
+                        dbUser.MothraId = foundUser.MothraId;
+                        await _dbContext.SaveChangesAsync();
+                    }
                 }
                 else if (accountLinksUpdated > 0)
                 {
@@ -204,7 +218,17 @@ namespace Hippo.Core.Services
                 };
 
                 var foundUser = await _identityService.GetByKerberos(newUser.Kerberos);
-                newUser.MothraId = foundUser.MothraId;
+                if (foundUser == null)
+                {
+                    Log.Warning(
+                        "Unable to set MothraId for new user with IAM {Iam} because Kerberos {Kerberos} could not be resolved uniquely in IAM.",
+                        newUser.Iam,
+                        newUser.Kerberos);
+                }
+                else
+                {
+                    newUser.MothraId = foundUser.MothraId;
+                }
 
                 await _dbContext.Users.AddAsync(newUser);
 

--- a/Test/AccountSyncPlannerTests.cs
+++ b/Test/AccountSyncPlannerTests.cs
@@ -137,5 +137,23 @@ namespace Test
             desiredMembership.AccountId.ShouldBe(100);
             desiredMembership.RevokedOn.ShouldBeNull();
         }
+
+        [Fact]
+        public void GetUniqueUserIdsByKerberos_SkipsAmbiguousKerberos()
+        {
+            var users = new[]
+            {
+                new UserKerberosSyncState(UserId: 1, Kerberos: "unique"),
+                new UserKerberosSyncState(UserId: 2, Kerberos: "duplicate"),
+                new UserKerberosSyncState(UserId: 3, Kerberos: "duplicate")
+            };
+
+            var userIdsByKerberos = AccountSyncPlanner.GetUniqueUserIdsByKerberos(users);
+
+            userIdsByKerberos.ShouldBe(new Dictionary<string, int>
+            {
+                ["unique"] = 1
+            });
+        }
     }
 }

--- a/Test/AccountSyncPlannerTests.cs
+++ b/Test/AccountSyncPlannerTests.cs
@@ -157,6 +157,41 @@ namespace Test
         }
 
         [Fact]
+        public void GetDesiredOwnerId_PreservesExistingOwnerWhenKerberosHasNoMatchingUser()
+        {
+            var userIdsByKerberos = new Dictionary<string, int>
+            {
+                ["unique"] = 1
+            };
+            var existingOwnerIdsByAccountKey = new Dictionary<(int ClusterId, string Kerberos), int?>
+            {
+                [(7, "missing")] = 42
+            };
+
+            var ownerId = AccountSyncPlanner.GetDesiredOwnerId(
+                7,
+                "missing",
+                userIdsByKerberos,
+                new HashSet<string>(),
+                existingOwnerIdsByAccountKey);
+
+            ownerId.ShouldBe(42);
+        }
+
+        [Fact]
+        public void GetDesiredOwnerId_ClearsOwnerWhenKerberosHasNoMatchingUserOrExistingOwner()
+        {
+            var ownerId = AccountSyncPlanner.GetDesiredOwnerId(
+                7,
+                "missing",
+                new Dictionary<string, int>(),
+                new HashSet<string>(),
+                new Dictionary<(int ClusterId, string Kerberos), int?>());
+
+            ownerId.ShouldBeNull();
+        }
+
+        [Fact]
         public void GetDesiredOwnerId_PreservesExistingOwnerWhenKerberosIsAmbiguous()
         {
             var userIdsByKerberos = new Dictionary<string, int>

--- a/Test/AccountSyncPlannerTests.cs
+++ b/Test/AccountSyncPlannerTests.cs
@@ -155,5 +155,28 @@ namespace Test
                 ["unique"] = 1
             });
         }
+
+        [Fact]
+        public void GetDesiredOwnerId_PreservesExistingOwnerWhenKerberosIsAmbiguous()
+        {
+            var userIdsByKerberos = new Dictionary<string, int>
+            {
+                ["unique"] = 1
+            };
+            var ambiguousKerberos = new HashSet<string> { "duplicate" };
+            var existingOwnerIdsByAccountKey = new Dictionary<(int ClusterId, string Kerberos), int?>
+            {
+                [(7, "duplicate")] = 42
+            };
+
+            var ownerId = AccountSyncPlanner.GetDesiredOwnerId(
+                7,
+                "duplicate",
+                userIdsByKerberos,
+                ambiguousKerberos,
+                existingOwnerIdsByAccountKey);
+
+            ownerId.ShouldBe(42);
+        }
     }
 }

--- a/Test/AccountSyncPlannerTests.cs
+++ b/Test/AccountSyncPlannerTests.cs
@@ -157,6 +157,88 @@ namespace Test
         }
 
         [Fact]
+        public void GetExistingOwnerIdsByAccountKey_PreservesUnambiguousExistingOwner()
+        {
+            var existingAccounts = new[]
+            {
+                new ExistingAccountOwnerSyncState(ClusterId: 7, Kerberos: "kerb", OwnerId: 42),
+                new ExistingAccountOwnerSyncState(ClusterId: 7, Kerberos: "kerb", OwnerId: 42)
+            };
+            var userIdsByKerberos = new Dictionary<string, int>
+            {
+                ["kerb"] = 1
+            };
+
+            var ownerIdsByAccountKey = AccountSyncPlanner.GetExistingOwnerIdsByAccountKey(
+                existingAccounts,
+                userIdsByKerberos);
+
+            ownerIdsByAccountKey.ShouldBe(new Dictionary<(int ClusterId, string Kerberos), int?>
+            {
+                [(7, "kerb")] = 42
+            });
+        }
+
+        [Fact]
+        public void GetExistingOwnerIdsByAccountKey_UsesUniqueKerberosUserWhenExistingOwnersConflict()
+        {
+            var existingAccounts = new[]
+            {
+                new ExistingAccountOwnerSyncState(ClusterId: 7, Kerberos: "kerb", OwnerId: 42),
+                new ExistingAccountOwnerSyncState(ClusterId: 7, Kerberos: "kerb", OwnerId: 43)
+            };
+            var userIdsByKerberos = new Dictionary<string, int>
+            {
+                ["kerb"] = 1
+            };
+
+            var ownerIdsByAccountKey = AccountSyncPlanner.GetExistingOwnerIdsByAccountKey(
+                existingAccounts,
+                userIdsByKerberos);
+
+            ownerIdsByAccountKey.ShouldBe(new Dictionary<(int ClusterId, string Kerberos), int?>
+            {
+                [(7, "kerb")] = 1
+            });
+        }
+
+        [Fact]
+        public void GetExistingOwnerIdsByAccountKey_DoesNotSelectOwnerWhenNoExistingOwnersAreSet()
+        {
+            var existingAccounts = new[]
+            {
+                new ExistingAccountOwnerSyncState(ClusterId: 7, Kerberos: "kerb", OwnerId: null),
+                new ExistingAccountOwnerSyncState(ClusterId: 7, Kerberos: "kerb", OwnerId: null)
+            };
+            var userIdsByKerberos = new Dictionary<string, int>
+            {
+                ["kerb"] = 1
+            };
+
+            var ownerIdsByAccountKey = AccountSyncPlanner.GetExistingOwnerIdsByAccountKey(
+                existingAccounts,
+                userIdsByKerberos);
+
+            ownerIdsByAccountKey.ShouldBeEmpty();
+        }
+
+        [Fact]
+        public void GetExistingOwnerIdsByAccountKey_DoesNotSelectOwnerWhenExistingOwnersConflictAndKerberosIsAmbiguous()
+        {
+            var existingAccounts = new[]
+            {
+                new ExistingAccountOwnerSyncState(ClusterId: 7, Kerberos: "kerb", OwnerId: 42),
+                new ExistingAccountOwnerSyncState(ClusterId: 7, Kerberos: "kerb", OwnerId: 43)
+            };
+
+            var ownerIdsByAccountKey = AccountSyncPlanner.GetExistingOwnerIdsByAccountKey(
+                existingAccounts,
+                new Dictionary<string, int>());
+
+            ownerIdsByAccountKey.ShouldBeEmpty();
+        }
+
+        [Fact]
         public void GetDesiredOwnerId_PreservesExistingOwnerWhenKerberosHasNoMatchingUser()
         {
             var userIdsByKerberos = new Dictionary<string, int>

--- a/Test/AccountSyncPlannerTests.cs
+++ b/Test/AccountSyncPlannerTests.cs
@@ -172,7 +172,27 @@ namespace Test
                 7,
                 "missing",
                 userIdsByKerberos,
-                new HashSet<string>(),
+                existingOwnerIdsByAccountKey);
+
+            ownerId.ShouldBe(42);
+        }
+
+        [Fact]
+        public void GetDesiredOwnerId_PreservesExistingOwnerWhenKerberosHasUniqueMatchingUser()
+        {
+            var userIdsByKerberos = new Dictionary<string, int>
+            {
+                ["kerb"] = 1
+            };
+            var existingOwnerIdsByAccountKey = new Dictionary<(int ClusterId, string Kerberos), int?>
+            {
+                [(7, "kerb")] = 42
+            };
+
+            var ownerId = AccountSyncPlanner.GetDesiredOwnerId(
+                7,
+                "kerb",
+                userIdsByKerberos,
                 existingOwnerIdsByAccountKey);
 
             ownerId.ShouldBe(42);
@@ -185,7 +205,6 @@ namespace Test
                 7,
                 "missing",
                 new Dictionary<string, int>(),
-                new HashSet<string>(),
                 new Dictionary<(int ClusterId, string Kerberos), int?>());
 
             ownerId.ShouldBeNull();
@@ -198,7 +217,6 @@ namespace Test
             {
                 ["unique"] = 1
             };
-            var ambiguousKerberos = new HashSet<string> { "duplicate" };
             var existingOwnerIdsByAccountKey = new Dictionary<(int ClusterId, string Kerberos), int?>
             {
                 [(7, "duplicate")] = 42
@@ -208,7 +226,6 @@ namespace Test
                 7,
                 "duplicate",
                 userIdsByKerberos,
-                ambiguousKerberos,
                 existingOwnerIdsByAccountKey);
 
             ownerId.ShouldBe(42);

--- a/Test/Helpers/TestDbContextFactory.cs
+++ b/Test/Helpers/TestDbContextFactory.cs
@@ -1,0 +1,17 @@
+using System;
+using Hippo.Core.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Test.Helpers;
+
+public static class TestDbContextFactory
+{
+    public static AppDbContextSqlServer Create()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContextSqlServer>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new AppDbContextSqlServer(options);
+    }
+}

--- a/Test/Helpers/TestDbContextFactory.cs
+++ b/Test/Helpers/TestDbContextFactory.cs
@@ -1,17 +1,25 @@
-using System;
 using Hippo.Core.Data;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 
 namespace Test.Helpers;
 
 public static class TestDbContextFactory
 {
-    public static AppDbContextSqlServer Create()
+    public static AppDbContextSqlite Create()
     {
-        var options = new DbContextOptionsBuilder<AppDbContextSqlServer>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+        SQLitePCL.Batteries_V2.Init();
+
+        var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+
+        var options = new DbContextOptionsBuilder<AppDbContextSqlite>()
+            .UseSqlite(connection, contextOwnsConnection: true)
             .Options;
 
-        return new AppDbContextSqlServer(options);
+        var dbContext = new AppDbContextSqlite(options);
+        dbContext.Database.EnsureCreated();
+
+        return dbContext;
     }
 }

--- a/Test/Services/AccountOwnershipServiceTests.cs
+++ b/Test/Services/AccountOwnershipServiceTests.cs
@@ -58,6 +58,40 @@ public class AccountOwnershipServiceTests
     }
 
     [Fact]
+    public async Task LinkAccountsToUser_DoesNotLinkWhenMultipleUsersHaveMatchingKerberos()
+    {
+        await using var dbContext = TestDbContextFactory.Create();
+        var cluster = new Cluster { Name = "farm" };
+        var user = new User
+        {
+            FirstName = "Pat",
+            LastName = "Requester",
+            Email = "pat@example.com",
+            Iam = "100000001",
+            Kerberos = "pat",
+            MothraId = "mothra1"
+        };
+        var duplicateUser = new User
+        {
+            FirstName = "Other",
+            LastName = "Requester",
+            Email = "other@example.com",
+            Iam = "100000002",
+            Kerberos = "pat",
+            MothraId = "mothra2"
+        };
+        var account = new Account { Cluster = cluster, Kerberos = "pat", Name = "Pat", Email = "pat@example.com" };
+        dbContext.AddRange(cluster, user, duplicateUser, account);
+        await dbContext.SaveChangesAsync();
+
+        var linkedCount = await AccountOwnershipService.LinkAccountsToUser(dbContext, user);
+        await dbContext.SaveChangesAsync();
+
+        linkedCount.ShouldBe(0);
+        account.OwnerId.ShouldBeNull();
+    }
+
+    [Fact]
     public async Task LinkAccountToMatchingUser_DoesNotOverwriteExistingOwner()
     {
         await using var dbContext = TestDbContextFactory.Create();
@@ -95,5 +129,40 @@ public class AccountOwnershipServiceTests
 
         linked.ShouldBeFalse();
         account.OwnerId.ShouldBe(currentOwner.Id);
+    }
+
+    [Fact]
+    public async Task LinkAccountToMatchingUser_DoesNotLinkWhenMultipleUsersHaveMatchingKerberos()
+    {
+        await using var dbContext = TestDbContextFactory.Create();
+        var cluster = new Cluster { Name = "farm" };
+        var account = new Account { Cluster = cluster, Kerberos = "pat", Name = "Pat", Email = "pat@example.com" };
+        dbContext.AddRange(
+            cluster,
+            account,
+            new User
+            {
+                FirstName = "Pat",
+                LastName = "Requester",
+                Email = "pat@example.com",
+                Iam = "100000001",
+                Kerberos = "pat",
+                MothraId = "mothra1"
+            },
+            new User
+            {
+                FirstName = "Other",
+                LastName = "Requester",
+                Email = "other@example.com",
+                Iam = "100000002",
+                Kerberos = "pat",
+                MothraId = "mothra2"
+            });
+        await dbContext.SaveChangesAsync();
+
+        var linked = await AccountOwnershipService.LinkAccountToMatchingUser(dbContext, account);
+
+        linked.ShouldBeFalse();
+        account.OwnerId.ShouldBeNull();
     }
 }

--- a/Test/Services/AccountOwnershipServiceTests.cs
+++ b/Test/Services/AccountOwnershipServiceTests.cs
@@ -1,0 +1,99 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Hippo.Core.Domain;
+using Hippo.Core.Services;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+using Test.Helpers;
+using Xunit;
+
+namespace Test.Services;
+
+public class AccountOwnershipServiceTests
+{
+    [Fact]
+    public async Task LinkAccountsToUser_LinksOnlyUnownedAccountsWithMatchingKerberos()
+    {
+        await using var dbContext = TestDbContextFactory.Create();
+        var cluster = new Cluster { Name = "farm" };
+        var user = new User
+        {
+            FirstName = "Pat",
+            LastName = "Requester",
+            Email = "pat@example.com",
+            Iam = "100000001",
+            Kerberos = "pat",
+            MothraId = "mothra1"
+        };
+        var otherUser = new User
+        {
+            FirstName = "Other",
+            LastName = "Owner",
+            Email = "other@example.com",
+            Iam = "100000002",
+            Kerberos = "other",
+            MothraId = "mothra2"
+        };
+
+        dbContext.AddRange(
+            cluster,
+            user,
+            otherUser,
+            new Account { Cluster = cluster, Kerberos = "pat", Name = "Pat", Email = "pat@example.com" },
+            new Account { Cluster = cluster, Kerberos = "other", Name = "Other", Email = "other@example.com" },
+            new Account { Cluster = cluster, Kerberos = "pat", Name = "Already Owned", Email = "owned@example.com", Owner = otherUser });
+        await dbContext.SaveChangesAsync();
+
+        var linkedCount = await AccountOwnershipService.LinkAccountsToUser(dbContext, user);
+        await dbContext.SaveChangesAsync();
+
+        linkedCount.ShouldBe(1);
+        var accounts = await dbContext.Accounts
+            .IgnoreQueryFilters()
+            .OrderBy(a => a.Name)
+            .ToListAsync();
+        accounts.Single(a => a.Name == "Pat").OwnerId.ShouldBe(user.Id);
+        accounts.Single(a => a.Name == "Other").OwnerId.ShouldBeNull();
+        accounts.Single(a => a.Name == "Already Owned").OwnerId.ShouldBe(otherUser.Id);
+    }
+
+    [Fact]
+    public async Task LinkAccountToMatchingUser_DoesNotOverwriteExistingOwner()
+    {
+        await using var dbContext = TestDbContextFactory.Create();
+        var cluster = new Cluster { Name = "farm" };
+        var matchingUser = new User
+        {
+            FirstName = "Pat",
+            LastName = "Requester",
+            Email = "pat@example.com",
+            Iam = "100000001",
+            Kerberos = "pat",
+            MothraId = "mothra1"
+        };
+        var currentOwner = new User
+        {
+            FirstName = "Current",
+            LastName = "Owner",
+            Email = "current@example.com",
+            Iam = "100000002",
+            Kerberos = "current",
+            MothraId = "mothra2"
+        };
+        var account = new Account
+        {
+            Cluster = cluster,
+            Kerberos = "pat",
+            Name = "Pat",
+            Email = "pat@example.com",
+            Owner = currentOwner
+        };
+        dbContext.AddRange(cluster, matchingUser, currentOwner, account);
+        await dbContext.SaveChangesAsync();
+
+        var linked = await AccountOwnershipService.LinkAccountToMatchingUser(dbContext, account);
+
+        linked.ShouldBeFalse();
+        account.OwnerId.ShouldBe(currentOwner.Id);
+    }
+}

--- a/Test/Services/AccountUpdateServiceTests.cs
+++ b/Test/Services/AccountUpdateServiceTests.cs
@@ -35,7 +35,8 @@ public class AccountUpdateServiceTests
             Cluster = cluster,
             Kerberos = "pat",
             Name = "Pat",
-            Email = "pat@example.com"
+            Email = "pat@example.com",
+            SshKey = "old-key"
         };
         dbContext.AddRange(cluster, user, group, syncedAccount);
         await dbContext.SaveChangesAsync();
@@ -53,6 +54,7 @@ public class AccountUpdateServiceTests
         }.WithAccountRequestData(new AccountRequestDataModel
         {
             AcceptableUsePolicyAgreedOn = acceptedAupOn,
+            SshKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITestRequestedKey",
             AccessTypes = new List<string>()
         });
         dbContext.Requests.Add(request);
@@ -82,6 +84,7 @@ public class AccountUpdateServiceTests
             .Include(a => a.MemberOfGroups)
             .SingleAsync(a => a.ClusterId == cluster.Id && a.Kerberos == user.Kerberos);
         account.OwnerId.ShouldBe(user.Id);
+        account.SshKey.ShouldBe("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITestRequestedKey");
         account.AcceptableUsePolicyAgreedOn.ShouldBe(acceptedAupOn);
         account.MemberOfGroups.Select(g => g.Id).ShouldContain(group.Id);
 
@@ -89,6 +92,70 @@ public class AccountUpdateServiceTests
             .IgnoreQueryFilters()
             .CountAsync(a => a.ClusterId == cluster.Id && a.Kerberos == user.Kerberos);
         accountCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task UpdateEvent_CompleteCreateAccount_AllowsIamResolvedUserWithEmptyKerberos()
+    {
+        await using var dbContext = TestDbContextFactory.Create();
+        var cluster = new Cluster { Name = "farm" };
+        var requester = new User
+        {
+            FirstName = "Pat",
+            LastName = "Requester",
+            Email = "pat@example.com",
+            Iam = "100000001",
+            Kerberos = "pat",
+            MothraId = "mothra1"
+        };
+        var iamResolvedUser = new User
+        {
+            FirstName = "Iam",
+            LastName = "Resolved",
+            Email = "iam@example.com",
+            Iam = "100000002",
+            Kerberos = "",
+            MothraId = "mothra2"
+        };
+        var group = new Group { Cluster = cluster, Name = "research", DisplayName = "Research" };
+        dbContext.AddRange(cluster, requester, iamResolvedUser, group);
+        await dbContext.SaveChangesAsync();
+
+        var request = new Request
+        {
+            Requester = requester,
+            RequesterId = requester.Id,
+            Group = group.Name,
+            Action = Request.Actions.CreateAccount,
+            Status = Request.Statuses.Processing,
+            Cluster = cluster,
+            ClusterId = cluster.Id
+        }.WithAccountRequestData(new AccountRequestDataModel());
+        dbContext.Requests.Add(request);
+        await dbContext.SaveChangesAsync();
+
+        var queuedEvent = new QueuedEvent
+        {
+            Action = QueuedEvent.Actions.CreateAccount,
+            Status = QueuedEvent.Statuses.Pending,
+            Data = QueuedEventDataModel.FromRequestAndGroup(request, group),
+            Request = request,
+            RequestId = request.Id
+        };
+        queuedEvent.Data.Accounts.Single().Iam = iamResolvedUser.Iam;
+        dbContext.QueuedEvents.Add(queuedEvent);
+        await dbContext.SaveChangesAsync();
+
+        var service = new AccountUpdateService(dbContext, new CapturingHistoryService());
+
+        var result = await service.UpdateEvent(queuedEvent, QueuedEvent.Statuses.Complete);
+
+        result.IsError.ShouldBeFalse();
+        queuedEvent.Status.ShouldBe(QueuedEvent.Statuses.Complete);
+        var account = await dbContext.Accounts
+            .IgnoreQueryFilters()
+            .SingleAsync(a => a.ClusterId == cluster.Id && a.Kerberos == requester.Kerberos);
+        account.OwnerId.ShouldBe(iamResolvedUser.Id);
     }
 
     [Fact]

--- a/Test/Services/AccountUpdateServiceTests.cs
+++ b/Test/Services/AccountUpdateServiceTests.cs
@@ -159,6 +159,71 @@ public class AccountUpdateServiceTests
         existingAccount.OwnerId.ShouldBe(existingOwner.Id);
     }
 
+    [Fact]
+    public async Task UpdateEvent_CompleteCreateAccount_FailsWhenKerberosMatchesMultipleUsersWithoutIam()
+    {
+        await using var dbContext = TestDbContextFactory.Create();
+        var cluster = new Cluster { Name = "farm" };
+        var requester = new User
+        {
+            FirstName = "Pat",
+            LastName = "Requester",
+            Email = "pat@example.com",
+            Iam = "100000001",
+            Kerberos = "pat",
+            MothraId = "mothra1"
+        };
+        var duplicateUser = new User
+        {
+            FirstName = "Other",
+            LastName = "Requester",
+            Email = "other@example.com",
+            Iam = "100000002",
+            Kerberos = "pat",
+            MothraId = "mothra2"
+        };
+        var group = new Group { Cluster = cluster, Name = "research", DisplayName = "Research" };
+        dbContext.AddRange(cluster, requester, duplicateUser, group);
+        await dbContext.SaveChangesAsync();
+
+        var request = new Request
+        {
+            Requester = requester,
+            RequesterId = requester.Id,
+            Group = group.Name,
+            Action = Request.Actions.CreateAccount,
+            Status = Request.Statuses.Processing,
+            Cluster = cluster,
+            ClusterId = cluster.Id
+        }.WithAccountRequestData(new AccountRequestDataModel());
+        dbContext.Requests.Add(request);
+        await dbContext.SaveChangesAsync();
+
+        var queuedEvent = new QueuedEvent
+        {
+            Action = QueuedEvent.Actions.CreateAccount,
+            Status = QueuedEvent.Statuses.Pending,
+            Data = QueuedEventDataModel.FromRequestAndGroup(request, group),
+            Request = request,
+            RequestId = request.Id
+        };
+        queuedEvent.Data.Accounts.Single().Iam = "";
+        dbContext.QueuedEvents.Add(queuedEvent);
+        await dbContext.SaveChangesAsync();
+
+        var service = new AccountUpdateService(dbContext, new CapturingHistoryService());
+
+        var result = await service.UpdateEvent(queuedEvent, QueuedEvent.Statuses.Complete);
+
+        result.IsError.ShouldBeTrue();
+        result.Message.ShouldBe("Multiple users found for Kerberos pat; cannot determine account owner");
+        queuedEvent.Status.ShouldBe(QueuedEvent.Statuses.Failed);
+        var accountCreated = await dbContext.Accounts
+            .IgnoreQueryFilters()
+            .AnyAsync(a => a.ClusterId == cluster.Id && a.Kerberos == requester.Kerberos);
+        accountCreated.ShouldBeFalse();
+    }
+
     private class CapturingHistoryService : IHistoryService
     {
         public List<History> AddedHistory { get; } = new();

--- a/Test/Services/AccountUpdateServiceTests.cs
+++ b/Test/Services/AccountUpdateServiceTests.cs
@@ -224,6 +224,71 @@ public class AccountUpdateServiceTests
         accountCreated.ShouldBeFalse();
     }
 
+    [Fact]
+    public async Task UpdateEvent_CompleteCreateAccount_FailsWhenIamResolvesToDifferentKerberos()
+    {
+        await using var dbContext = TestDbContextFactory.Create();
+        var cluster = new Cluster { Name = "farm" };
+        var requester = new User
+        {
+            FirstName = "Pat",
+            LastName = "Requester",
+            Email = "pat@example.com",
+            Iam = "100000001",
+            Kerberos = "pat",
+            MothraId = "mothra1"
+        };
+        var otherUser = new User
+        {
+            FirstName = "Other",
+            LastName = "User",
+            Email = "other@example.com",
+            Iam = "100000002",
+            Kerberos = "other",
+            MothraId = "mothra2"
+        };
+        var group = new Group { Cluster = cluster, Name = "research", DisplayName = "Research" };
+        dbContext.AddRange(cluster, requester, otherUser, group);
+        await dbContext.SaveChangesAsync();
+
+        var request = new Request
+        {
+            Requester = requester,
+            RequesterId = requester.Id,
+            Group = group.Name,
+            Action = Request.Actions.CreateAccount,
+            Status = Request.Statuses.Processing,
+            Cluster = cluster,
+            ClusterId = cluster.Id
+        }.WithAccountRequestData(new AccountRequestDataModel());
+        dbContext.Requests.Add(request);
+        await dbContext.SaveChangesAsync();
+
+        var queuedEvent = new QueuedEvent
+        {
+            Action = QueuedEvent.Actions.CreateAccount,
+            Status = QueuedEvent.Statuses.Pending,
+            Data = QueuedEventDataModel.FromRequestAndGroup(request, group),
+            Request = request,
+            RequestId = request.Id
+        };
+        queuedEvent.Data.Accounts.Single().Iam = otherUser.Iam;
+        dbContext.QueuedEvents.Add(queuedEvent);
+        await dbContext.SaveChangesAsync();
+
+        var service = new AccountUpdateService(dbContext, new CapturingHistoryService());
+
+        var result = await service.UpdateEvent(queuedEvent, QueuedEvent.Statuses.Complete);
+
+        result.IsError.ShouldBeTrue();
+        result.Message.ShouldBe("Queued account Kerberos pat does not match resolved user Kerberos other");
+        queuedEvent.Status.ShouldBe(QueuedEvent.Statuses.Failed);
+        var accountCreated = await dbContext.Accounts
+            .IgnoreQueryFilters()
+            .AnyAsync(a => a.ClusterId == cluster.Id && a.Kerberos == requester.Kerberos);
+        accountCreated.ShouldBeFalse();
+    }
+
     private class CapturingHistoryService : IHistoryService
     {
         public List<History> AddedHistory { get; } = new();

--- a/Test/Services/AccountUpdateServiceTests.cs
+++ b/Test/Services/AccountUpdateServiceTests.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Hippo.Core.Domain;
+using Hippo.Core.Extensions;
+using Hippo.Core.Models;
+using Hippo.Core.Services;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+using Test.Helpers;
+using Xunit;
+
+namespace Test.Services;
+
+public class AccountUpdateServiceTests
+{
+    [Fact]
+    public async Task UpdateEvent_CompleteCreateAccount_LinksExistingSyncedAccount()
+    {
+        await using var dbContext = TestDbContextFactory.Create();
+        var cluster = new Cluster { Name = "farm" };
+        var user = new User
+        {
+            FirstName = "Pat",
+            LastName = "Requester",
+            Email = "pat@example.com",
+            Iam = "100000001",
+            Kerberos = "pat",
+            MothraId = "mothra1"
+        };
+        var group = new Group { Cluster = cluster, Name = "research", DisplayName = "Research" };
+        var syncedAccount = new Account
+        {
+            Cluster = cluster,
+            Kerberos = "pat",
+            Name = "Pat",
+            Email = "pat@example.com"
+        };
+        dbContext.AddRange(cluster, user, group, syncedAccount);
+        await dbContext.SaveChangesAsync();
+
+        var acceptedAupOn = new DateTime(2026, 7, 1, 12, 0, 0, DateTimeKind.Utc);
+        var request = new Request
+        {
+            Requester = user,
+            RequesterId = user.Id,
+            Group = group.Name,
+            Action = Request.Actions.CreateAccount,
+            Status = Request.Statuses.Processing,
+            Cluster = cluster,
+            ClusterId = cluster.Id
+        }.WithAccountRequestData(new AccountRequestDataModel
+        {
+            AcceptableUsePolicyAgreedOn = acceptedAupOn,
+            AccessTypes = new List<string>()
+        });
+        dbContext.Requests.Add(request);
+        await dbContext.SaveChangesAsync();
+
+        var queuedEvent = new QueuedEvent
+        {
+            Action = QueuedEvent.Actions.CreateAccount,
+            Status = QueuedEvent.Statuses.Pending,
+            Data = QueuedEventDataModel.FromRequestAndGroup(request, group),
+            Request = request,
+            RequestId = request.Id
+        };
+        dbContext.QueuedEvents.Add(queuedEvent);
+        await dbContext.SaveChangesAsync();
+
+        var service = new AccountUpdateService(dbContext, new CapturingHistoryService());
+
+        var result = await service.UpdateEvent(queuedEvent, QueuedEvent.Statuses.Complete);
+
+        result.IsError.ShouldBeFalse();
+        queuedEvent.Status.ShouldBe(QueuedEvent.Statuses.Complete);
+        request.Status.ShouldBe(Request.Statuses.Completed);
+
+        var account = await dbContext.Accounts
+            .IgnoreQueryFilters()
+            .Include(a => a.MemberOfGroups)
+            .SingleAsync(a => a.ClusterId == cluster.Id && a.Kerberos == user.Kerberos);
+        account.OwnerId.ShouldBe(user.Id);
+        account.AcceptableUsePolicyAgreedOn.ShouldBe(acceptedAupOn);
+        account.MemberOfGroups.Select(g => g.Id).ShouldContain(group.Id);
+
+        var accountCount = await dbContext.Accounts
+            .IgnoreQueryFilters()
+            .CountAsync(a => a.ClusterId == cluster.Id && a.Kerberos == user.Kerberos);
+        accountCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task UpdateEvent_CompleteCreateAccount_FailsWhenExistingAccountBelongsToAnotherUser()
+    {
+        await using var dbContext = TestDbContextFactory.Create();
+        var cluster = new Cluster { Name = "farm" };
+        var requester = new User
+        {
+            FirstName = "Pat",
+            LastName = "Requester",
+            Email = "pat@example.com",
+            Iam = "100000001",
+            Kerberos = "pat",
+            MothraId = "mothra1"
+        };
+        var existingOwner = new User
+        {
+            FirstName = "Existing",
+            LastName = "Owner",
+            Email = "owner@example.com",
+            Iam = "100000002",
+            Kerberos = "owner",
+            MothraId = "mothra2"
+        };
+        var group = new Group { Cluster = cluster, Name = "research", DisplayName = "Research" };
+        var existingAccount = new Account
+        {
+            Cluster = cluster,
+            Kerberos = "pat",
+            Name = "Pat",
+            Email = "pat@example.com",
+            Owner = existingOwner
+        };
+        dbContext.AddRange(cluster, requester, existingOwner, group, existingAccount);
+        await dbContext.SaveChangesAsync();
+
+        var request = new Request
+        {
+            Requester = requester,
+            RequesterId = requester.Id,
+            Group = group.Name,
+            Action = Request.Actions.CreateAccount,
+            Status = Request.Statuses.Processing,
+            Cluster = cluster,
+            ClusterId = cluster.Id
+        }.WithAccountRequestData(new AccountRequestDataModel());
+        dbContext.Requests.Add(request);
+        await dbContext.SaveChangesAsync();
+
+        var queuedEvent = new QueuedEvent
+        {
+            Action = QueuedEvent.Actions.CreateAccount,
+            Status = QueuedEvent.Statuses.Pending,
+            Data = QueuedEventDataModel.FromRequestAndGroup(request, group),
+            Request = request,
+            RequestId = request.Id
+        };
+        dbContext.QueuedEvents.Add(queuedEvent);
+        await dbContext.SaveChangesAsync();
+
+        var service = new AccountUpdateService(dbContext, new CapturingHistoryService());
+
+        var result = await service.UpdateEvent(queuedEvent, QueuedEvent.Statuses.Complete);
+
+        result.IsError.ShouldBeTrue();
+        queuedEvent.Status.ShouldBe(QueuedEvent.Statuses.Failed);
+        existingAccount.OwnerId.ShouldBe(existingOwner.Id);
+    }
+
+    private class CapturingHistoryService : IHistoryService
+    {
+        public List<History> AddedHistory { get; } = new();
+
+        public Task AddHistory(History history, string clusterName = null!)
+        {
+            AddedHistory.Add(history);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Test/Services/UserServiceTests.cs
+++ b/Test/Services/UserServiceTests.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Hippo.Core.Domain;
+using Hippo.Core.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+using Test.Helpers;
+using Xunit;
+
+namespace Test.Services;
+
+public class UserServiceTests
+{
+    [Fact]
+    public async Task GetUser_WhenUserAlreadyExists_LinksMatchingUnownedAccounts()
+    {
+        await using var dbContext = TestDbContextFactory.Create();
+        var cluster = new Cluster { Name = "farm" };
+        var user = new User
+        {
+            FirstName = "Pat",
+            LastName = "Requester",
+            Email = "pat@example.com",
+            Iam = "100000001",
+            Kerberos = "pat",
+            MothraId = "mothra1"
+        };
+        var account = new Account
+        {
+            Cluster = cluster,
+            Kerberos = "pat",
+            Name = "Pat",
+            Email = "pat@example.com"
+        };
+        dbContext.AddRange(cluster, user, account);
+        await dbContext.SaveChangesAsync();
+
+        var userService = new UserService(dbContext, new HttpContextAccessor(), new ThrowingIdentityService());
+
+        var result = await userService.GetUser(new[]
+        {
+            new Claim(UserService.IamIdClaimType, user.Iam),
+            new Claim(ClaimTypes.GivenName, user.FirstName),
+            new Claim(ClaimTypes.Surname, user.LastName),
+            new Claim(ClaimTypes.Email, user.Email),
+            new Claim(ClaimTypes.NameIdentifier, user.Kerberos)
+        });
+
+        result.Id.ShouldBe(user.Id);
+        var linkedAccount = await dbContext.Accounts.IgnoreQueryFilters().SingleAsync(a => a.Id == account.Id);
+        linkedAccount.OwnerId.ShouldBe(user.Id);
+    }
+
+    private class ThrowingIdentityService : IIdentityService
+    {
+        public Task<User> GetByEmail(string email)
+        {
+            throw new InvalidOperationException("This test should not call the identity service.");
+        }
+
+        public Task<User> GetByKerberos(string kerb)
+        {
+            throw new InvalidOperationException("This test should not call the identity service.");
+        }
+
+        public Task<User> GetByIamId(string iamId)
+        {
+            throw new InvalidOperationException("This test should not call the identity service.");
+        }
+    }
+}

--- a/Test/Services/UserServiceTests.cs
+++ b/Test/Services/UserServiceTests.cs
@@ -53,6 +53,48 @@ public class UserServiceTests
         linkedAccount.OwnerId.ShouldBe(user.Id);
     }
 
+    [Fact]
+    public async Task GetUser_WhenNewUserKerberosMatchesExistingUser_DoesNotLinkAccounts()
+    {
+        await using var dbContext = TestDbContextFactory.Create();
+        var cluster = new Cluster { Name = "farm" };
+        var existingUser = new User
+        {
+            FirstName = "Existing",
+            LastName = "User",
+            Email = "existing@example.com",
+            Iam = "100000001",
+            Kerberos = "pat",
+            MothraId = "mothra1"
+        };
+        var account = new Account
+        {
+            Cluster = cluster,
+            Kerberos = "pat",
+            Name = "Pat",
+            Email = "pat@example.com"
+        };
+        dbContext.AddRange(cluster, existingUser, account);
+        await dbContext.SaveChangesAsync();
+
+        var userService = new UserService(dbContext, new HttpContextAccessor(), new NullIdentityService());
+
+        var result = await userService.GetUser(new[]
+        {
+            new Claim(UserService.IamIdClaimType, "100000002"),
+            new Claim(ClaimTypes.GivenName, "Pat"),
+            new Claim(ClaimTypes.Surname, "Requester"),
+            new Claim(ClaimTypes.Email, "pat@example.com"),
+            new Claim(ClaimTypes.NameIdentifier, "pat")
+        });
+
+        result.Id.ShouldNotBe(existingUser.Id);
+        var linkedAccount = await dbContext.Accounts.IgnoreQueryFilters().SingleAsync(a => a.Id == account.Id);
+        linkedAccount.OwnerId.ShouldBeNull();
+        var matchingUsers = await dbContext.Users.CountAsync(u => u.Kerberos == "pat");
+        matchingUsers.ShouldBe(2);
+    }
+
     private class ThrowingIdentityService : IIdentityService
     {
         public Task<User> GetByEmail(string email)
@@ -68,6 +110,24 @@ public class UserServiceTests
         public Task<User> GetByIamId(string iamId)
         {
             throw new InvalidOperationException("This test should not call the identity service.");
+        }
+    }
+
+    private class NullIdentityService : IIdentityService
+    {
+        public Task<User> GetByEmail(string email)
+        {
+            return Task.FromResult<User>(null!);
+        }
+
+        public Task<User> GetByKerberos(string kerb)
+        {
+            return Task.FromResult<User>(null!);
+        }
+
+        public Task<User> GetByIamId(string iamId)
+        {
+            return Task.FromResult<User>(null!);
         }
     }
 }

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -6,7 +6,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AspNetCore.TestHelpers" Version="1.1.14" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.14" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.14" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.6" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AspNetCore.TestHelpers" Version="1.1.14" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.14" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />


### PR DESCRIPTION
## Summary

- Improves account ownership linking when users and synced accounts share Kerberos IDs.
- Avoids assigning ownership when Kerberos matches are ambiguous.
- Preserves existing account owners during sync instead of clearing them for duplicate Kerberos cases.
- Validates queued create-account events so IAM/Kerberos mismatches fail safely.
- Adds regression tests for ownership linking, sync ownership preservation, and queued event validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically links accounts to matching users when ownership is unassigned, including during group and account update flows.
  * Improves ownership selection during account synchronization to handle ambiguous identity data while preserving existing ownership when appropriate.
* **Bug Fixes**
  * Avoids hard failures on non-unique Kerberos lookups; ambiguous matches are skipped and warnings are logged.
  * Prevents overwriting an account’s existing owner during linking.
* **Tests**
  * Adds/expands unit tests for ownership linking, synchronization ownership mapping, account update create flows, and user provisioning.
  * Introduces SQLite-backed test context support for more reliable service tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->